### PR TITLE
Update the way that events are triggered

### DIFF
--- a/src/BjyAuthorize/Guard/Controller.php
+++ b/src/BjyAuthorize/Guard/Controller.php
@@ -105,13 +105,10 @@ class Controller extends AbstractGuard
         /* @var $app \Laminas\Mvc\ApplicationInterface */
         $app = $event->getTarget();
         $eventManager = $app->getEventManager();
-        $eventManager->setEventPrototype($event);
 
-        $results = $eventManager->trigger(
-            MvcEvent::EVENT_DISPATCH_ERROR,
-            null,
-            $event->getParams()
-        );
+        $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
+        $results = $eventManager->triggerEvent($event);
+
         $return  = $results->last();
         if (! $return) {
             return $event->getResult();

--- a/src/BjyAuthorize/Guard/Route.php
+++ b/src/BjyAuthorize/Guard/Route.php
@@ -67,13 +67,10 @@ class Route extends AbstractGuard
         /* @var $app \Laminas\Mvc\Application */
         $app = $event->getTarget();
         $eventManager = $app->getEventManager();
-        $eventManager->setEventPrototype($event);
 
-        $results = $eventManager->trigger(
-            MvcEvent::EVENT_DISPATCH_ERROR,
-            null,
-            $event->getParams()
-        );
+        $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
+        $results = $eventManager->triggerEvent($event);
+
         $return  = $results->last();
         if (! $return) {
             return $event->getResult();

--- a/tests/BjyAuthorizeTest/Guard/ControllerTest.php
+++ b/tests/BjyAuthorizeTest/Guard/ControllerTest.php
@@ -149,7 +149,7 @@ class ControllerTest extends TestCase
     public function testOnDispatchWithValidController()
     {
         $event = $this->createMvcEvent('test-controller');
-        $event->getTarget()->getEventManager()->expects($this->never())->method('trigger');
+        $event->getTarget()->getEventManager()->expects($this->never())->method('triggerEvent');
         $this
             ->authorize
             ->expects($this->any())
@@ -171,7 +171,7 @@ class ControllerTest extends TestCase
     public function testOnDispatchWithValidControllerAndAction()
     {
         $event = $this->createMvcEvent('test-controller', 'test-action');
-        $event->getTarget()->getEventManager()->expects($this->never())->method('trigger');
+        $event->getTarget()->getEventManager()->expects($this->never())->method('triggerEvent');
         $this
             ->authorize
             ->expects($this->any())
@@ -193,7 +193,7 @@ class ControllerTest extends TestCase
     public function testOnDispatchWithValidControllerAndMethod()
     {
         $event = $this->createMvcEvent('test-controller', null, 'PUT');
-        $event->getTarget()->getEventManager()->expects($this->never())->method('trigger');
+        $event->getTarget()->getEventManager()->expects($this->never())->method('triggerEvent');
         $this
             ->authorize
             ->expects($this->any())
@@ -215,7 +215,7 @@ class ControllerTest extends TestCase
     public function testOnDispatchWithValidControllerAction()
     {
         $event = $this->createMvcEvent('test-controller', 'test-action');
-        $event->getTarget()->getEventManager()->expects($this->never())->method('trigger');
+        $event->getTarget()->getEventManager()->expects($this->never())->method('triggerEvent');
         $this
             ->authorize
             ->expects($this->any())
@@ -251,12 +251,13 @@ class ControllerTest extends TestCase
         $responseCollection = $this->getMockBuilder(\Laminas\EventManager\ResponseCollection::class)
             ->getMock();
 
+        $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
         $event
             ->getTarget()
             ->getEventManager()
             ->expects($this->once())
-            ->method('trigger')
-            ->with(MvcEvent::EVENT_DISPATCH_ERROR, null, [])
+            ->method('triggerEvent')
+            ->with($event)
             ->willReturn($responseCollection);
 
         $this->assertNull($this->controllerGuard->onDispatch($event), 'Does not stop event propagation');

--- a/tests/BjyAuthorizeTest/Guard/RouteTest.php
+++ b/tests/BjyAuthorizeTest/Guard/RouteTest.php
@@ -176,7 +176,7 @@ class RouteTest extends TestCase
     public function testOnRouteWithValidRoute()
     {
         $event = $this->createMvcEvent('test-route');
-        $event->getTarget()->getEventManager()->expects($this->never())->method('trigger');
+        $event->getTarget()->getEventManager()->expects($this->never())->method('triggerEvent');
         $this
             ->authorize
             ->expects($this->any())
@@ -216,12 +216,13 @@ class RouteTest extends TestCase
         $responseCollection = $this->getMockBuilder(\Laminas\EventManager\ResponseCollection::class)
             ->getMock();
 
+        $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
         $event
             ->getTarget()
             ->getEventManager()
             ->expects($this->once())
-            ->method('trigger')
-            ->with(MvcEvent::EVENT_DISPATCH_ERROR, null, $event->getParams())
+            ->method('triggerEvent')
+            ->with($event)
             ->willReturn($responseCollection);
 
         $this->assertNull($this->routeGuard->onRoute($event), 'Does not stop event propagation');


### PR DESCRIPTION
as noted in issue #16 this PR fix the problem of retreiving `$event->getResult()` after it has been triggered