### PR TITLE
Added option to fully disable caching

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -41,6 +41,9 @@ return [
         // Template name for the unauthorized strategy
         'template'              => 'error/403',
 
+        // Flag if cache should be enabled or not
+        'cache_enabled'         => true,
+
         // cache options have to be compatible with Laminas\Cache\StorageFactory::factory
         'cache_options'         => [
             'adapter'   => [

--- a/src/BjyAuthorize/Service/Authorize.php
+++ b/src/BjyAuthorize/Service/Authorize.php
@@ -268,11 +268,15 @@ class Authorize
         $cacheKey = $cacheKeyGenerator();
 
         $success = false;
-        $this->acl = $cache->getItem($cacheKey, $success);
+        if ($this->config['cache_enabled']) {
+            $this->acl = $cache->getItem($cacheKey, $success);
+        }
 
         if (!($this->acl instanceof Acl) || !$success) {
             $this->loadAcl();
-            $cache->setItem($cacheKey, $this->acl);
+            if ($this->config['cache_enabled']) {
+                $cache->setItem($cacheKey, $this->acl);
+            }
         }
 
         $this->setIdentityProvider($this->serviceLocator->get('BjyAuthorize\Provider\Identity\ProviderInterface'));


### PR DESCRIPTION
BjyAuthorize, by configuration, always wants to cache the whole acl. This can become problematic when using assertion, since assertions my have dependencies to other services of the application that may not be cachable. For example, an assertion might require a service with a database connection, which then throws the following error:

```
Fatal error: Uncaught Exception: Serialization of 'Doctrine\DBAL\Driver\PDOConnection' is not allowed in /var/www/vendor/laminas/laminas-serializer/src/Adapter/PhpSerialize.php:
85
Stack trace:
#0 /var/www/vendor/laminas/laminas-serializer/src/Adapter/PhpSerialize.php(85): serialize(Object(Laminas\Permissions\Acl\Acl))
#1 /var/www/vendor/laminas/laminas-cache/src/Storage/Plugin/Serializer.php(105): Laminas\Serializer\Adapter\PhpSerialize->serialize(Object(Laminas\Permissions\Acl\Acl))
#2 /var/www/vendor/laminas/laminas-eventmanager/src/EventManager.php(331): Laminas\Cache\Storage\Plugin\Serializer->onWriteItemPre(Object(Laminas\Cache\Storage\Event))
#3 /var/www/vendor/laminas/laminas-eventmanager/src/EventManager.php(180): Laminas\EventManager\EventManager->triggerListeners(Object(Laminas\Cache\Storage\Event))
#4 /var/www/vendor/laminas/laminas-cache/src/Storage/Adapter/AbstractAdapter.php(206): Laminas\EventManager\EventManager->triggerEvent(Object(Laminas\Cache\Storage\Event))
#5 /var/www/vendor/laminas/laminas-cache/src in /var/www/vendor/laminas/laminas-serializer/src/Adapter/PhpSerialize.php on line 85
```

The problem has already been described here:
 - https://github.com/bjyoungblood/BjyAuthorize/issues/213
 - https://stackoverflow.com/questions/30198466/zend-using-entitymanager-in-assertion

Since serializing assertions is not really possible, the best is to avoid caching in such case. The problem is, that BjyAuthorize by default always wants to serialize the ACL, even if only the memory cache adapter is used. This is because of BjyAuthorizes's default config:

```
        // cache options have to be compatible with Laminas\Cache\StorageFactory::factory
        'cache_options'         => [
            'adapter'   => [
                'name' => 'memory',
            ],
            'plugins'   => [
                'serializer',
            ]
        ],
```

This PR introduces a new config option "cache_enabled", which by default is true. This ensures that the current behaviour of the module does not change through the introduction of the new config option. However, by settings this option to false, users using assertions can effectively disable caching and, hence, prevent such serialization problems from happening.