### PR TITLE
Updated dependencies allowing PHP 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 composer.lock
 composer.phar
 clover.xml
+phpunit.xml
 vendor
 .idea
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BjyAuthorize - Acl security for Laminas
 
-[![Build Status](https://travis-ci.com/kokspflanze/BjyAuthorize.png?branch=master)](https://travis-ci.com/kokspflanze/BjyAuthorize)
+[![Continuous Integration](https://github.com/kokspflanze/BjyAuthorize/actions/workflows/continous-integration.yml/badge.svg)](https://github.com/kokspflanze/BjyAuthorize/actions/workflows/continous-integration.yml)
 [![Total Downloads](https://poser.pugx.org/kokspflanze/bjy-authorize/downloads.png)](https://packagist.org/packages/kokspflanze/bjy-authorize)
 [![Latest Stable Version](https://poser.pugx.org/kokspflanze/bjy-authorize/v/stable.png)](https://packagist.org/packages/kokspflanze/bjy-authorize)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BjyAuthorize - Acl security for Laminas / ZF3
+# BjyAuthorize - Acl security for Laminas
 
 [![Build Status](https://travis-ci.com/kokspflanze/BjyAuthorize.png?branch=master)](https://travis-ci.com/kokspflanze/BjyAuthorize)
 [![Total Downloads](https://poser.pugx.org/kokspflanze/bjy-authorize/downloads.png)](https://packagist.org/packages/kokspflanze/bjy-authorize)
@@ -12,7 +12,7 @@ setup via config files or by using `Laminas\Db` or Doctrine ORM/ODM.
 ## Information
 
 this is a fork of [bjyoungblood/BjyAuthorize](https://github.com/bjyoungblood/BjyAuthorize).
-I added Laminas/ZF3 support, so the module works with Laminas / Zend Framework 2 and 3.
+I added Laminas support, so the module works with Laminas. Releases before 2.0 work with Zend Framework 2 and 3.
 If you found a bug, please report it, just pm me in [gitter](https://gitter.im/kokspflanze) or open a PullRequest.
 
 ## What does BjyAuthorize do?
@@ -30,7 +30,7 @@ And here's how it would look like with BjyAuthorize enabled:
 
 ## Requirements
 
- * [Laminas](https://getlaminas.org/) / [Zend Framework 2](https://github.com/zendframework/zf2)
+ * [Laminas](https://getlaminas.org/)
  * [LmcUser](https://github.com/LM-Commons/LmcUser) (optional)
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -1,54 +1,51 @@
 {
     "name":         "kokspflanze/bjy-authorize",
-    "description":  "Laminas\\Acl based firewall system for Laminas/ZF2/3 dispatch protection",
+    "description":  "Laminas\\Acl based firewall system for Laminas dispatch protection",
     "type":         "library",
     "license":      "BSD-3-Clause",
     "homepage":     "https://github.com/kokspflanze/BjyAuthorize",
     "keywords": [
         "laminas",
-        "zf",
-        "zf2",
-        "zf3",
         "acl",
-        "lmc-user",
-        "zfc-user"
+        "authorization",
+        "lmc-user"
     ],
     "authors": [
         {
-            "name":      "Ben Youngblood",
-            "email":     "bx.youngblood@gmail.com",
-            "homepage":  "http://bjyoungblood.com/",
-            "role":      "Developer"
+            "name":     "Ben Youngblood",
+            "email":    "bx.youngblood@gmail.com",
+            "homepage": "http://bjyoungblood.com/",
+            "role":     "Developer"
         },
         {
-            "name":      "Marco Pivetta",
-            "email":     "ocramius@gmail.com",
-            "homepage":  "http://ocramius.github.com/",
-            "role":      "Developer"
+            "name":     "Marco Pivetta",
+            "email":    "ocramius@gmail.com",
+            "homepage": "http://ocramius.github.com/",
+            "role":     "Developer"
         }
     ],
     "require": {
-        "php": "^7.3",
-        "laminas/laminas-permissions-acl": "^2.7",
-        "laminas/laminas-mvc":             "^3.2",
-        "laminas/laminas-eventmanager":    "^3.3",
-        "laminas/laminas-servicemanager":  "^3.6",
-        "laminas/laminas-http":            "^2.14",
-        "laminas/laminas-view":            "^2.12",
-        "laminas/laminas-authentication":  "^2.7",
-        "laminas/laminas-cache":           "^2.10"
+        "php": "^7.3 || ~8.0.0",
+        "laminas/laminas-permissions-acl": "^2.8.0",
+        "laminas/laminas-mvc":             "^3.2.0",
+        "laminas/laminas-eventmanager":    "^3.4.0",
+        "laminas/laminas-servicemanager":  "^3.7.0",
+        "laminas/laminas-http":            "^2.15.0",
+        "laminas/laminas-view":            "^2.12.0",
+        "laminas/laminas-authentication":  "^2.8.0",
+        "laminas/laminas-cache":           "^2.13.0"
     },
     "require-dev": {
-        "phpunit/phpunit":                 "^9.5",
-        "laminas/laminas-console":         "^2.8",
-        "laminas/laminas-db":              "^2.12",
-        "doctrine/persistence":            "^1.3.3 || ^2.0",
-        "laminas/laminas-developer-tools": "^2.1",
-        "lm-commons/lmc-user":             "^3.1"
+        "phpunit/phpunit":                 "^9.5.9",
+        "laminas/laminas-console":         "^2.8.0",
+        "laminas/laminas-db":              "^2.13.4",
+        "doctrine/persistence":            "^1.3.8 || ^2.2.2",
+        "laminas/laminas-developer-tools": "^2.1.1",
+        "lm-commons/lmc-user":             "^3.5.0"
     },
     "suggests": {
-        "laminas/laminas-developer-tools": "if you need to see current authorization details while developing",
-        "lm-commons/lmc-user":             "LmcUser provides a good default setup to get started with bjyauthorize",
+        "laminas/laminas-developer-tools":  "if you need to see current authorization details while developing",
+        "lm-commons/lmc-user":              "LmcUser provides a good default setup to get started with bjyauthorize",
         "lm-commons/lmc-user-doctrine-orm": "To support Doctrine with LmcUser"
     },
     "autoload": {


### PR DESCRIPTION
This PR updates all dependencies to their latest version supporting PHP 7.3. For most dependencies that is their latest version in general, except for `laminas-servicemanager`, which dropped PHP 7.3 in 3.8.0 and, hence, has to stay a version 3.7.0.

As a side effect, the library can now be used with PHP 8.0 (closes #30). Technically, there are still some storage adapters from `laminas-cache` which are not 8.0 compatible. However, [laminas-ci-matrix-action](https://github.com/laminas/laminas-ci-matrix-action) handles this in the CI environment.

For end users of this library, my comment from #30 still applies. They need to [avoid installing unused cache adapters](https://docs.laminas.dev/laminas-cache/installation/#avoid-unused-cache-adapters-are-being-installed) as it is mentioned in laminas cache's documentation.