### PR TITLE
Fixed wrong config path

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -86,11 +86,21 @@ return [
             Service\AuthorizeAwareServiceInitializer::class
         ],
     ],
+    'controller_plugins' => [
+        'factories' => [
+            'isAllowed' => Controller\Plugin\IsAllowedFactory::class
+        ],
+    ],
     'view_manager' => [
         'template_map' => [
             'error/403' => __DIR__ . '/../view/error/403.phtml',
             'laminas-developer-tools/toolbar/bjy-authorize-role'
                 => __DIR__ . '/../view/laminas-developer-tools/toolbar/bjy-authorize-role.phtml',
+        ],
+    ],
+    'view_helpers' => [
+        'factories' => [
+            'isAllowed' => View\Helper\IsAllowedFactory::class,
         ],
     ],
     'laminas-developer-tools' => [

--- a/src/Module.php
+++ b/src/Module.php
@@ -82,6 +82,6 @@ class Module implements
      */
     public function getConfig()
     {
-        return include __DIR__ . '/../../config/module.config.php';
+        return include __DIR__ . '/../config/module.config.php';
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -2,15 +2,11 @@
 
 namespace BjyAuthorize;
 
-use BjyAuthorize\Controller\Plugin;
 use BjyAuthorize\Guard\AbstractGuard;
-use BjyAuthorize\View\Helper;
 use BjyAuthorize\View\UnauthorizedStrategy;
 use Laminas\EventManager\EventInterface;
 use Laminas\ModuleManager\Feature\BootstrapListenerInterface;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
-use Laminas\ModuleManager\Feature\ControllerPluginProviderInterface;
-use Laminas\ModuleManager\Feature\ViewHelperProviderInterface;
 use Laminas\ServiceManager\ServiceManager;
 
 /**
@@ -20,9 +16,7 @@ use Laminas\ServiceManager\ServiceManager;
  */
 class Module implements
     BootstrapListenerInterface,
-    ConfigProviderInterface,
-    ControllerPluginProviderInterface,
-    ViewHelperProviderInterface
+    ConfigProviderInterface
 {
     /**
      * {@inheritDoc}
@@ -51,30 +45,6 @@ class Module implements
         }
 
         $strategy->attach($app->getEventManager());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getViewHelperConfig()
-    {
-        return [
-            'factories' => [
-                'isAllowed' => Helper\IsAllowedFactory::class,
-            ],
-        ];
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getControllerPluginConfig()
-    {
-        return [
-            'factories' => [
-                'isAllowed' => Plugin\IsAllowedFactory::class
-            ],
-        ];
     }
 
     /**

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace BjyAuthorizeTest;
+
+use BjyAuthorize\Guard\Controller;
+use BjyAuthorize\Guard\Route;
+use BjyAuthorize\Module;
+use BjyAuthorize\View\UnauthorizedStrategy;
+use Laminas\EventManager\EventManager;
+use Laminas\Mvc\Application;
+use Laminas\Mvc\MvcEvent;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+
+class ModuleTest extends TestCase
+{
+    public function testIfModuleConfigIsLoaded()
+    {
+        $module = new Module();
+        $config = $module->getConfig();
+
+        $this->assertIsArray($config);
+        $this->assertArrayHasKey('bjyauthorize', $config);
+        $this->assertArrayHasKey('service_manager', $config);
+        $this->assertArrayHasKey('controller_plugins', $config);
+        $this->assertArrayHasKey('view_manager', $config);
+        $this->assertArrayHasKey('view_helpers', $config);
+        $this->assertArrayHasKey('laminas-developer-tools', $config);
+    }
+
+    public function testIfBoostrapRegistersGuardsAndStrategy()
+    {
+        $module = new Module();
+        $event = $this->getMockedBootstrapEvent();
+
+        $module->onBootstrap($event);
+    }
+
+    protected function getMockedBootstrapEvent()
+    {
+        $guard1 = $this->getMockBuilder(Controller::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $guard1->expects($this->once())
+            ->method('attach');
+
+        $guard2 = $this->getMockBuilder(Route::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $guard2->expects($this->once())
+            ->method('attach');
+
+        $strategy = $this->getMockBuilder(UnauthorizedStrategy::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $strategy->expects($this->once())
+            ->method('attach');
+
+        $serviceManager = $this->getMockBuilder(ServiceManager::class)
+            ->getMock();
+
+        $serviceManager->expects($this->any())
+            ->method('get')
+            ->will($this->returnCallback(function(string $name) use ($guard1, $guard2, $strategy) {
+                switch ($name) {
+                    case 'BjyAuthorize\Config':
+                        return ['unauthorized_strategy' => 'my_unauthorized_strategy'];
+                    case 'my_unauthorized_strategy':
+                        return $strategy;
+                    case 'BjyAuthorize\Guards':
+                        return [$guard1, $guard2];
+                    default:
+                        throw new \InvalidArgumentException('Invalid service call.');
+                }
+            }));
+
+        $eventManager = $this->getMockBuilder(EventManager::class)
+            ->getMock();
+
+        $app = $this->getMockBuilder(Application::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $app->expects($this->any())
+            ->method('getServiceManager')
+            ->willReturn($serviceManager);
+
+        $app->expects($this->any())
+            ->method('getEventManager')
+            ->willReturn($eventManager);
+
+        $event = $this->getMockBuilder(MvcEvent::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event->expects($this->any())
+            ->method('getTarget')
+            ->willReturn($app);
+
+        return $event;
+    }
+}


### PR DESCRIPTION
@kokspflanze In e7039c13cb39684b82c1cb9fc788e7baf804cd36 the files from `src/BjyAuthorize/` were moved to `src/`, but the path to `module.config.php` was not adjusted. That breaks the current `dev-master` version. This branch fixes the wrong path.