### PR TITLE
Added and applied Laminas coding standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     },
     "require-dev": {
         "phpunit/phpunit":                 "^9.5.9",
+        "laminas/laminas-coding-standard": "^2.3.0",
         "laminas/laminas-console":         "^2.8.0",
         "laminas/laminas-db":              "^2.13.4",
         "doctrine/persistence":            "^1.3.8 || ^2.2.2",
@@ -59,6 +60,12 @@
         }
     },
     "scripts": {
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "cs-check": "phpcs",
+        "cs-fix": "phpcbf",
         "test": "phpunit --colors=always --configuration phpunit.xml.dist"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<ruleset name="Laminas coding standard">
+    <rule ref="./vendor/laminas/laminas-coding-standard/src/LaminasCodingStandard/ruleset.xml"/>
+
+    <!-- Paths to check -->
+    <file>src</file>
+    <file>test</file>
+</ruleset>

--- a/src/Acl/HierarchicalRoleInterface.php
+++ b/src/Acl/HierarchicalRoleInterface.php
@@ -1,20 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Acl;
 
 use Laminas\Permissions\Acl\Role\RoleInterface;
 
 /**
  * Interface for a role with a possible parent role.
- *
- * @author Tom Oram <tom@scl.co.uk>
  */
 interface HierarchicalRoleInterface extends RoleInterface
 {
     /**
      * Get the parent role
      *
-     * @return \Laminas\Permissions\Acl\Role\RoleInterface|null
+     * @return RoleInterface|null
      */
     public function getParent();
 }

--- a/src/Acl/Role.php
+++ b/src/Acl/Role.php
@@ -1,25 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Acl;
 
 use BjyAuthorize\Exception;
+use BjyAuthorize\Exception\InvalidRoleException;
 use Laminas\Permissions\Acl\Role\RoleInterface;
+
+use function is_string;
 
 /**
  * Base role object
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class Role implements RoleInterface, HierarchicalRoleInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $roleId;
 
-    /**
-     * @var RoleInterface
-     */
+    /** @var RoleInterface */
     protected $parent;
 
     /**
@@ -46,12 +45,11 @@ class Role implements RoleInterface, HierarchicalRoleInterface
 
     /**
      * @param string $roleId
-     *
      * @return self
      */
     public function setRoleId($roleId)
     {
-        $this->roleId = (string)$roleId;
+        $this->roleId = (string) $roleId;
 
         return $this;
     }
@@ -66,9 +64,7 @@ class Role implements RoleInterface, HierarchicalRoleInterface
 
     /**
      * @param RoleInterface|string|null $parent
-     *
-     * @throws \BjyAuthorize\Exception\InvalidRoleException
-     *
+     * @throws InvalidRoleException
      * @return self
      */
     public function setParent($parent)

--- a/src/Collector/RoleCollector.php
+++ b/src/Collector/RoleCollector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Collector;
 
 use BjyAuthorize\Provider\Identity\ProviderInterface;
@@ -7,31 +9,27 @@ use Laminas\DeveloperTools\Collector\CollectorInterface;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Permissions\Acl\Role\RoleInterface;
 use Serializable;
+use Traversable;
+
+use function is_array;
+use function serialize;
+use function unserialize;
 
 /**
  * Role collector - collects the role during dispatch
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RoleCollector implements CollectorInterface, Serializable
 {
-    const NAME = 'bjy_authorize_role_collector';
+    public const NAME = 'bjy_authorize_role_collector';
 
-    const PRIORITY = 150;
+    public const PRIORITY = 150;
 
-    /**
-     * @var array|string[] collected role ids
-     */
+    /** @var array|string[] collected role ids */
     protected $collectedRoles = [];
 
-    /**
-     * @var \BjyAuthorize\Provider\Identity\ProviderInterface|null
-     */
+    /** @var ProviderInterface|null */
     protected $identityProvider;
 
-    /**
-     * @param \BjyAuthorize\Provider\Identity\ProviderInterface $identityProvider
-     */
     public function __construct(ProviderInterface $identityProvider)
     {
         $this->identityProvider = $identityProvider;
@@ -58,14 +56,14 @@ class RoleCollector implements CollectorInterface, Serializable
      */
     public function collect(MvcEvent $mvcEvent)
     {
-        if (!$this->identityProvider) {
+        if (! $this->identityProvider) {
             return;
         }
 
         $roles = $this->identityProvider->getIdentityRoles();
 
-        if (!is_array($roles) && !$roles instanceof \Traversable) {
-            $roles = (array)$roles;
+        if (! is_array($roles) && ! $roles instanceof Traversable) {
+            $roles = (array) $roles;
         }
 
         foreach ($roles as $role) {
@@ -74,7 +72,7 @@ class RoleCollector implements CollectorInterface, Serializable
             }
 
             if ($role) {
-                $this->collectedRoles[] = (string)$role;
+                $this->collectedRoles[] = (string) $role;
             }
         }
     }

--- a/src/Controller/Plugin/IsAllowed.php
+++ b/src/Controller/Plugin/IsAllowed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Controller\Plugin;
 
 use BjyAuthorize\Service\Authorize;
@@ -7,19 +9,12 @@ use Laminas\Mvc\Controller\Plugin\AbstractPlugin;
 
 /**
  * IsAllowed Controller plugin. Allows checking access to a resource/privilege in controllers.
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class IsAllowed extends AbstractPlugin
 {
-    /**
-     * @var Authorize
-     */
+    /** @var Authorize */
     protected $authorizeService;
 
-    /**
-     * @param Authorize $authorizeService
-     */
     public function __construct(Authorize $authorizeService)
     {
         $this->authorizeService = $authorizeService;
@@ -28,7 +23,6 @@ class IsAllowed extends AbstractPlugin
     /**
      * @param mixed $resource
      * @param mixed|null $privilege
-     *
      * @return bool
      */
     public function __invoke($resource, $privilege = null)

--- a/src/Controller/Plugin/IsAllowedFactory.php
+++ b/src/Controller/Plugin/IsAllowedFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Controller\Plugin;
 
 use BjyAuthorize\Service\Authorize;
@@ -20,12 +22,11 @@ class IsAllowedFactory implements FactoryInterface
     }
 
     /**
-     * @param ContainerInterface $container
      * @param string $requestedName
      * @param array|null $options
      * @return IsAllowed
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $authorize = $container->get(Authorize::class);
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Exception;
 
 use InvalidArgumentException as BaseInvalidArgumentException;

--- a/src/Exception/InvalidRoleException.php
+++ b/src/Exception/InvalidRoleException.php
@@ -1,6 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Exception;
+
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 /**
  * Invalid role exception for BjyAuthorize
@@ -9,7 +16,6 @@ class InvalidRoleException extends InvalidArgumentException
 {
     /**
      * @param mixed $role
-     *
      * @return self
      */
     public static function invalidRoleInstance($role)

--- a/src/Exception/UnAuthorizedException.php
+++ b/src/Exception/UnAuthorizedException.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Exception;
+
+use BadMethodCallException;
 
 /**
  * Exception to be thrown in case of unauthorized access to a resource
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
-class UnAuthorizedException extends \BadMethodCallException
+class UnAuthorizedException extends BadMethodCallException
 {
 }

--- a/src/Guard/AbstractGuard.php
+++ b/src/Guard/AbstractGuard.php
@@ -1,4 +1,8 @@
-<?php /** @noinspection ALL */
+<?php
+
+/** @noinspection ALL */
+
+declare(strict_types=1);
 
 namespace BjyAuthorize\Guard;
 
@@ -7,37 +11,30 @@ use BjyAuthorize\Provider\Rule\ProviderInterface as RuleProviderInterface;
 use Interop\Container\ContainerInterface;
 use Laminas\EventManager\AbstractListenerAggregate;
 
+use function array_keys;
+
 abstract class AbstractGuard extends AbstractListenerAggregate implements
     GuardInterface,
     RuleProviderInterface,
     ResourceProviderInterface
 {
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     protected $container;
 
-    /**
-     * @var array[]
-     */
+    /** @var array[] */
     protected $rules = [];
 
     /**
-     *
      * @param array $rules
-     * @param ContainerInterface $container
      */
     public function __construct(array $rules, ContainerInterface $container)
     {
         $this->container = $container;
-
         foreach ($rules as $rule) {
-            $rule['roles'] = (array)$rule['roles'];
-            $rule['action'] = isset($rule['action']) ? (array)$rule['action'] : [null];
-
+            $rule['roles']  = (array) $rule['roles'];
+            $rule['action'] = isset($rule['action']) ? (array) $rule['action'] : [null];
             foreach ($this->extractResourcesFromRule($rule) as $resource) {
-                $this->rules[$resource] = ['roles' => (array)$rule['roles']];
-
+                $this->rules[$resource] = ['roles' => (array) $rule['roles']];
                 if (isset($rule['assertion'])) {
                     $this->rules[$resource]['assertion'] = $rule['assertion'];
                 }
@@ -53,7 +50,6 @@ abstract class AbstractGuard extends AbstractListenerAggregate implements
     public function getResources()
     {
         $resources = [];
-
         foreach (array_keys($this->rules) as $resource) {
             $resources[] = $resource;
         }
@@ -68,12 +64,12 @@ abstract class AbstractGuard extends AbstractListenerAggregate implements
     {
         $rules = [];
         foreach ($this->rules as $resource => $ruleData) {
-            $rule = [];
+            $rule   = [];
             $rule[] = $ruleData['roles'];
             $rule[] = $resource;
-
             if (isset($ruleData['assertion'])) {
-                $rule[] = null; // no privilege
+                $rule[] = null;
+        // no privilege
                 $rule[] = $ruleData['assertion'];
             }
 

--- a/src/Guard/Controller.php
+++ b/src/Guard/Controller.php
@@ -82,7 +82,7 @@ class Controller extends AbstractGuard
         $controller = $match->getParam('controller');
         $action     = $match->getParam('action');
         $request    = $event->getRequest();
-        $method     = $request instanceof HttpRequest ? strtolower($request->getMethod()) : null;
+        $method     = $request instanceof HttpRequest ? strtolower((string) $request->getMethod()) : null;
 
         $authorized = (class_exists(ConsoleRequest::class) && $event->getRequest() instanceof ConsoleRequest)
             || $service->isAllowed($this->getResourceName($controller))

--- a/src/Guard/Controller.php
+++ b/src/Guard/Controller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Guard;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
@@ -7,27 +9,33 @@ use BjyAuthorize\Service\Authorize;
 use Laminas\Console\Request as ConsoleRequest;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Http\Request as HttpRequest;
+use Laminas\Mvc\ApplicationInterface;
 use Laminas\Mvc\MvcEvent;
+
+use function class_exists;
+use function sprintf;
+use function strtolower;
 
 /**
  * Controller Guard listener, allows checking of permissions
  * during {@see \Laminas\Mvc\MvcEvent::EVENT_DISPATCH}
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class Controller extends AbstractGuard
 {
     /**
      * Marker for invalid route errors
      */
-    const ERROR = 'error-unauthorized-controller';
+    public const ERROR = 'error-unauthorized-controller';
 
+    /**
+     * @return array
+     */
     protected function extractResourcesFromRule(array $rule)
     {
-        $results = [];
-        $rule['action'] = isset($rule['action']) ? (array)$rule['action'] : [null];
+        $results        = [];
+        $rule['action'] = isset($rule['action']) ? (array) $rule['action'] : [null];
 
-        foreach ((array)$rule['controller'] as $controller) {
+        foreach ((array) $rule['controller'] as $controller) {
             foreach ($rule['action'] as $action) {
                 $results[] = $this->getResourceName($controller, $action);
             }
@@ -49,7 +57,6 @@ class Controller extends AbstractGuard
      *
      * @param string $controller
      * @param string $action
-     *
      * @return string
      */
     public function getResourceName($controller, $action = null)
@@ -65,19 +72,17 @@ class Controller extends AbstractGuard
      * Event callback to be triggered on dispatch, causes application error triggering
      * in case of failed authorization check
      *
-     * @param MvcEvent $event
-     *
      * @return mixed
      */
     public function onDispatch(MvcEvent $event)
     {
-        /* @var $service \BjyAuthorize\Service\Authorize */
-        $service = $this->container->get(Authorize::class);
-        $match = $event->getRouteMatch();
+        /** @var Authorize $service */
+        $service    = $this->container->get(Authorize::class);
+        $match      = $event->getRouteMatch();
         $controller = $match->getParam('controller');
-        $action = $match->getParam('action');
-        $request = $event->getRequest();
-        $method = $request instanceof HttpRequest ? strtolower($request->getMethod()) : null;
+        $action     = $match->getParam('action');
+        $request    = $event->getRequest();
+        $method     = $request instanceof HttpRequest ? strtolower($request->getMethod()) : null;
 
         $authorized = (class_exists(ConsoleRequest::class) && $event->getRequest() instanceof ConsoleRequest)
             || $service->isAllowed($this->getResourceName($controller))
@@ -96,14 +101,14 @@ class Controller extends AbstractGuard
         $errorMessage = sprintf("You are not authorized to access %s:%s", $controller, $action);
         $event->setParam('exception', new UnAuthorizedException($errorMessage));
 
-        /* @var $app \Laminas\Mvc\ApplicationInterface */
-        $app = $event->getTarget();
+        /** @var ApplicationInterface $app */
+        $app          = $event->getTarget();
         $eventManager = $app->getEventManager();
 
         $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
         $results = $eventManager->triggerEvent($event);
 
-        $return  = $results->last();
+        $return = $results->last();
         if (! $return) {
             return $event->getResult();
         }

--- a/src/Guard/GuardInterface.php
+++ b/src/Guard/GuardInterface.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Guard;
 
 use Laminas\EventManager\ListenerAggregateInterface;
 
 /**
  * Interface for generic guard listeners
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 interface GuardInterface extends ListenerAggregateInterface
 {

--- a/src/Guard/Route.php
+++ b/src/Guard/Route.php
@@ -1,26 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Guard;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
 use BjyAuthorize\Service\Authorize;
 use Laminas\Console\Request as ConsoleRequest;
 use Laminas\EventManager\EventManagerInterface;
+use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
+
+use function class_exists;
 
 /**
  * Route Guard listener, allows checking of permissions
  * during {@see \Laminas\Mvc\MvcEvent::EVENT_ROUTE}
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class Route extends AbstractGuard
 {
     /**
      * Marker for invalid route errors
      */
-    const ERROR = 'error-unauthorized-route';
+    public const ERROR = 'error-unauthorized-route';
 
+    /**
+     * @return string[]
+     */
     protected function extractResourcesFromRule(array $rule)
     {
         return ['route/' . $rule['route']];
@@ -38,34 +44,39 @@ class Route extends AbstractGuard
      * Event callback to be triggered on dispatch, causes application error triggering
      * in case of failed authorization check
      *
-     * @param MvcEvent $event
-     *
      * @return mixed
      */
     public function onRoute(MvcEvent $event)
     {
-        /* @var $service \BjyAuthorize\Service\Authorize */
-        $service = $this->container->get(Authorize::class);
-        $match = $event->getRouteMatch();
+        /** @var Authorize $service */
+        $service   = $this->container->get(Authorize::class);
+        $match     = $event->getRouteMatch();
         $routeName = $match->getMatchedRouteName();
 
-        if ($service->isAllowed('route/' . $routeName) || (class_exists(ConsoleRequest::class) && $event->getRequest() instanceof ConsoleRequest)) {
+        if (
+            $service->isAllowed('route/' . $routeName)
+            || (class_exists(ConsoleRequest::class)
+            && $event->getRequest() instanceof ConsoleRequest)
+        ) {
             return;
         }
 
         $event->setError(static::ERROR);
         $event->setParam('route', $routeName);
         $event->setParam('identity', $service->getIdentity());
-        $event->setParam('exception', new UnAuthorizedException('You are not authorized to access ' . $routeName));
+        $event->setParam(
+            'exception',
+            new UnAuthorizedException('You are not authorized to access ' . $routeName)
+        );
 
-        /* @var $app \Laminas\Mvc\Application */
-        $app = $event->getTarget();
+        /** @var Application $app */
+        $app          = $event->getTarget();
         $eventManager = $app->getEventManager();
 
         $event->setName(MvcEvent::EVENT_DISPATCH_ERROR);
         $results = $eventManager->triggerEvent($event);
 
-        $return  = $results->last();
+        $return = $results->last();
         if (! $return) {
             return $event->getResult();
         }

--- a/src/Module.php
+++ b/src/Module.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize;
 
 use BjyAuthorize\Guard\AbstractGuard;
@@ -7,12 +9,11 @@ use BjyAuthorize\View\UnauthorizedStrategy;
 use Laminas\EventManager\EventInterface;
 use Laminas\ModuleManager\Feature\BootstrapListenerInterface;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
+use Laminas\Mvc\ApplicationInterface;
 use Laminas\ServiceManager\ServiceManager;
 
 /**
  * BjyAuthorize Module
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class Module implements
     BootstrapListenerInterface,
@@ -23,11 +24,11 @@ class Module implements
      */
     public function onBootstrap(EventInterface $event)
     {
-        /* @var $app \Laminas\Mvc\ApplicationInterface */
+        /** @var ApplicationInterface $app */
         $app = $event->getTarget();
         /** @var ServiceManager $serviceManager */
         $serviceManager = $app->getServiceManager();
-        $config = $serviceManager->get('BjyAuthorize\Config');
+        $config         = $serviceManager->get('BjyAuthorize\Config');
         /** @var UnauthorizedStrategy $strategy */
         $strategy = $serviceManager->get($config['unauthorized_strategy']);
         /** @var AbstractGuard[] $guards */

--- a/src/Provider/Identity/AuthenticationIdentityProvider.php
+++ b/src/Provider/Identity/AuthenticationIdentityProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Identity;
 
 use BjyAuthorize\Exception\InvalidRoleException;
@@ -7,31 +9,22 @@ use BjyAuthorize\Provider\Role\ProviderInterface as RoleProviderInterface;
 use Laminas\Authentication\AuthenticationService;
 use Laminas\Permissions\Acl\Role\RoleInterface;
 
+use function is_string;
+
 /**
  * Simple identity provider to handle simply guest|user
- *
- * @author Ingo Walz <ingo.walz@googlemail.com>
  */
 class AuthenticationIdentityProvider implements ProviderInterface
 {
-    /**
-     * @var AuthenticationService
-     */
+    /** @var AuthenticationService */
     protected $authService;
 
-    /**
-     * @var string|\Laminas\Permissions\Acl\Role\RoleInterface
-     */
+    /** @var string|RoleInterface */
     protected $defaultRole = 'guest';
 
-    /**
-     * @var string|\Laminas\Permissions\Acl\Role\RoleInterface
-     */
+    /** @var string|RoleInterface */
     protected $authenticatedRole = 'user';
 
-    /**
-     * @param AuthenticationService $authService
-     */
     public function __construct(AuthenticationService $authService)
     {
         $this->authService = $authService;
@@ -42,7 +35,7 @@ class AuthenticationIdentityProvider implements ProviderInterface
      */
     public function getIdentityRoles()
     {
-        if (!$identity = $this->authService->getIdentity()) {
+        if (! $identity = $this->authService->getIdentity()) {
             return [$this->defaultRole];
         }
 
@@ -60,7 +53,7 @@ class AuthenticationIdentityProvider implements ProviderInterface
     /**
      * Get the rule that's used if you're not authenticated
      *
-     * @return string|\Laminas\Permissions\Acl\Role\RoleInterface
+     * @return string|RoleInterface
      */
     public function getDefaultRole()
     {
@@ -70,13 +63,12 @@ class AuthenticationIdentityProvider implements ProviderInterface
     /**
      * Set the rule that's used if you're not authenticated
      *
-     * @param $defaultRole
-     *
-     * @throws \BjyAuthorize\Exception\InvalidRoleException
+     * @param  string|RoleInterface $defaultRole
+     * @throws InvalidRoleException
      */
     public function setDefaultRole($defaultRole)
     {
-        if (!($defaultRole instanceof RoleInterface || is_string($defaultRole))) {
+        if (! ($defaultRole instanceof RoleInterface || is_string($defaultRole))) {
             throw InvalidRoleException::invalidRoleInstance($defaultRole);
         }
 
@@ -86,7 +78,7 @@ class AuthenticationIdentityProvider implements ProviderInterface
     /**
      * Get the role that is used if you're authenticated and the identity provides no role
      *
-     * @return string|\Laminas\Permissions\Acl\Role\RoleInterface
+     * @return string|RoleInterface
      */
     public function getAuthenticatedRole()
     {
@@ -96,14 +88,12 @@ class AuthenticationIdentityProvider implements ProviderInterface
     /**
      * Set the role that is used if you're authenticated and the identity provides no role
      *
-     * @param string|\Laminas\Permissions\Acl\Role\RoleInterface $authenticatedRole
-     *
-     * @throws \BjyAuthorize\Exception\InvalidRoleException
-     *
+     * @param string|RoleInterface $authenticatedRole
+     * @throws InvalidRoleException
      */
     public function setAuthenticatedRole($authenticatedRole)
     {
-        if (!($authenticatedRole instanceof RoleInterface || is_string($authenticatedRole))) {
+        if (! ($authenticatedRole instanceof RoleInterface || is_string($authenticatedRole))) {
             throw InvalidRoleException::invalidRoleInstance($authenticatedRole);
         }
 

--- a/src/Provider/Identity/LmcUserLaminasDb.php
+++ b/src/Provider/Identity/LmcUserLaminasDb.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Identity;
 
 use BjyAuthorize\Exception\InvalidRoleException;
@@ -8,41 +10,29 @@ use Laminas\Db\TableGateway\TableGateway;
 use Laminas\Permissions\Acl\Role\RoleInterface;
 use LmcUser\Service\User;
 
+use function is_string;
+
 /**
  * Identity provider based on {@see \Laminas\Db\Adapter\Adapter}
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class LmcUserLaminasDb implements ProviderInterface
 {
-    /**
-     * @var User
-     */
+    /** @var User */
     protected $userService;
 
-    /**
-     * @var string|\Laminas\Permissions\Acl\Role\RoleInterface
-     */
+    /** @var string|RoleInterface */
     protected $defaultRole;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $tableName = 'user_role_linker';
 
-    /**
-     * @var \Laminas\Db\TableGateway\TableGateway
-     */
+    /** @var TableGateway */
     private $tableGateway;
 
-    /**
-     * @param \Laminas\Db\TableGateway\TableGateway $tableGateway
-     * @param \LmcUser\Service\User $userService
-     */
     public function __construct(TableGateway $tableGateway, User $userService)
     {
         $this->tableGateway = $tableGateway;
-        $this->userService = $userService;
+        $this->userService  = $userService;
     }
 
     /**
@@ -52,7 +42,7 @@ class LmcUserLaminasDb implements ProviderInterface
     {
         $authService = $this->userService->getAuthService();
 
-        if (!$authService->hasIdentity()) {
+        if (! $authService->hasIdentity()) {
             return [$this->getDefaultRole()];
         }
 
@@ -76,7 +66,7 @@ class LmcUserLaminasDb implements ProviderInterface
     }
 
     /**
-     * @return string|\Laminas\Permissions\Acl\Role\RoleInterface
+     * @return string|RoleInterface
      */
     public function getDefaultRole()
     {
@@ -84,13 +74,12 @@ class LmcUserLaminasDb implements ProviderInterface
     }
 
     /**
-     * @param string|\Laminas\Permissions\Acl\Role\RoleInterface $defaultRole
-     *
-     * @throws \BjyAuthorize\Exception\InvalidRoleException
+     * @param string|RoleInterface $defaultRole
+     * @throws InvalidRoleException
      */
     public function setDefaultRole($defaultRole)
     {
-        if (!($defaultRole instanceof RoleInterface || is_string($defaultRole))) {
+        if (! ($defaultRole instanceof RoleInterface || is_string($defaultRole))) {
             throw InvalidRoleException::invalidRoleInstance($defaultRole);
         }
 

--- a/src/Provider/Identity/ProviderInterface.php
+++ b/src/Provider/Identity/ProviderInterface.php
@@ -1,19 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Identity;
+
+use Laminas\Permissions\Acl\Role\RoleInterface;
 
 /**
  * Interface for identity providers, which are objects capable of
  * retrieving an active identity's role
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 interface ProviderInterface
 {
     /**
      * Retrieve roles for the current identity
      *
-     * @return string[]|\Laminas\Permissions\Acl\Role\RoleInterface[]
+     * @return string[]|RoleInterface[]
      */
     public function getIdentityRoles();
 }

--- a/src/Provider/Resource/Config.php
+++ b/src/Provider/Resource/Config.php
@@ -1,21 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Resource;
+
+use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 /**
  * Array-based resources list
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class Config implements ProviderInterface
 {
-    /**
-     * @var \Laminas\Permissions\Acl\Resource\ResourceInterface[]
-     */
+    /** @var ResourceInterface[] */
     protected $resources = [];
 
     /**
-     * @param \Laminas\Permissions\Acl\Resource\ResourceInterface[] $config
+     * @param ResourceInterface[] $config
      */
     public function __construct(array $config = [])
     {

--- a/src/Provider/Resource/ProviderInterface.php
+++ b/src/Provider/Resource/ProviderInterface.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Resource;
+
+use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 /**
  * Resource provider interface, provides existing resources list
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 interface ProviderInterface
 {
     /**
-     * @return \Laminas\Permissions\Acl\Resource\ResourceInterface[]
+     * @return ResourceInterface[]
      */
     public function getResources();
 }

--- a/src/Provider/Role/Config.php
+++ b/src/Provider/Role/Config.php
@@ -1,19 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Role;
 
 use BjyAuthorize\Acl\Role;
+use Laminas\Permissions\Acl\Role\RoleInterface;
+
+use function array_merge;
+use function count;
+use function is_numeric;
 
 /**
  * Array config based Role provider
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class Config implements ProviderInterface
 {
-    /**
-     * @var \Laminas\Permissions\Acl\Role\RoleInterface[]
-     */
+    /** @var RoleInterface[] */
     protected $roles = [];
 
     /**
@@ -38,7 +41,6 @@ class Config implements ProviderInterface
      * @param string $name
      * @param array $options
      * @param string|null $parent
-     *
      * @return array
      */
     protected function loadRole($name, $options = [], $parent = null)
@@ -49,8 +51,8 @@ class Config implements ProviderInterface
             $children = [];
         }
 
-        $roles = [];
-        $role = new Role($name, $parent);
+        $roles   = [];
+        $role    = new Role($name, $parent);
         $roles[] = $role;
 
         foreach ($children as $key => $value) {

--- a/src/Provider/Role/LaminasDb.php
+++ b/src/Provider/Role/LaminasDb.php
@@ -1,46 +1,38 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Role;
 
 use BjyAuthorize\Acl\Role;
 use Interop\Container\ContainerInterface;
 use Laminas\Db\Sql\Select;
+use Laminas\Db\TableGateway\TableGateway;
+
+use function array_values;
 
 /**
  * Role provider based on a {@see \Laminas\Db\Adaper\Adapter}
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class LaminasDb implements ProviderInterface
 {
-    /**
-     * @var ContainerInterface
-     */
+    /** @var ContainerInterface */
     protected $serviceLocator;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $tableName = 'user_role';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $identifierFieldName = 'id';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $roleIdFieldName = 'role_id';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $parentRoleFieldName = 'parent_id';
 
     /**
-     * @param                         $options
-     * @param ContainerInterface $serviceLocator
+     * @param array $options Options
      */
     public function __construct($options, ContainerInterface $serviceLocator)
     {
@@ -68,16 +60,16 @@ class LaminasDb implements ProviderInterface
      */
     public function getRoles()
     {
-        /* @var $tableGateway \Laminas\Db\TableGateway\TableGateway */
+        /** @var TableGateway $tableGateway */
         $tableGateway = $this->serviceLocator->get('BjyAuthorize\Service\RoleDbTableGateway');
-        $sql = new Select();
+        $sql          = new Select();
 
         $sql->from($this->tableName);
 
-        /* @var $roles Role[] */
-        $roles = [];
+        /** @var Role[] $roles */
+        $roles       = [];
         $indexedRows = [];
-        $rowset = $tableGateway->selectWith($sql);
+        $rowset      = $tableGateway->selectWith($sql);
 
         // Pass 1: collect all rows and index them by PK
         foreach ($rowset as $row) {
@@ -86,9 +78,9 @@ class LaminasDb implements ProviderInterface
 
         // Pass 2: build a role for each indexed row
         foreach ($indexedRows as $row) {
-            $parentRoleId = isset($row[$this->parentRoleFieldName])
+            $parentRoleId   = isset($row[$this->parentRoleFieldName])
                 ? $indexedRows[$row[$this->parentRoleFieldName]][$this->roleIdFieldName] : null;
-            $roleId = $row[$this->roleIdFieldName];
+            $roleId         = $row[$this->roleIdFieldName];
             $roles[$roleId] = new Role($roleId, $parentRoleId);
         }
 

--- a/src/Provider/Role/ObjectRepositoryProvider.php
+++ b/src/Provider/Role/ObjectRepositoryProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Role;
 
 use BjyAuthorize\Acl\HierarchicalRoleInterface;
@@ -7,21 +9,16 @@ use BjyAuthorize\Acl\Role;
 use Doctrine\Persistence\ObjectRepository;
 use Laminas\Permissions\Acl\Role\RoleInterface;
 
+use function array_values;
+
 /**
  * Role provider based on a {@see \Doctrine\Persistence\ObjectRepository}
- *
- * @author Tom Oram <tom@scl.co.uk>
  */
 class ObjectRepositoryProvider implements ProviderInterface
 {
-    /**
-     * @var \Doctrine\Persistence\ObjectRepository
-     */
+    /** @var ObjectRepository */
     protected $objectRepository;
 
-    /**
-     * @param \Doctrine\Persistence\ObjectRepository $objectRepository
-     */
     public function __construct(ObjectRepository $objectRepository)
     {
         $this->objectRepository = $objectRepository;
@@ -33,11 +30,11 @@ class ObjectRepositoryProvider implements ProviderInterface
     public function getRoles()
     {
         $result = $this->objectRepository->findAll();
-        $roles = [];
+        $roles  = [];
 
         // Pass One: Build each object
         foreach ($result as $role) {
-            if (!$role instanceof RoleInterface) {
+            if (! $role instanceof RoleInterface) {
                 continue;
             }
 
@@ -52,7 +49,7 @@ class ObjectRepositoryProvider implements ProviderInterface
         }
 
         // Pass Two: Re-inject parent objects to preserve hierarchy
-        /* @var $roleObj \BjyAuthorize\Acl\Role */
+        /** @var Role $roleObj */
         foreach ($roles as $roleObj) {
             $parentRoleObj = $roleObj->getParent();
 

--- a/src/Provider/Role/ProviderInterface.php
+++ b/src/Provider/Role/ProviderInterface.php
@@ -1,16 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Role;
+
+use Laminas\Permissions\Acl\Role\RoleInterface;
 
 /**
  * Role provider interface, provides existing roles list
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 interface ProviderInterface
 {
     /**
-     * @return \Laminas\Permissions\Acl\Role\RoleInterface[]
+     * @return RoleInterface[]
      */
     public function getRoles();
 }

--- a/src/Provider/Rule/Config.php
+++ b/src/Provider/Rule/Config.php
@@ -1,17 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Rule;
 
 /**
  * Rule provider based on a given array of rules
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class Config implements ProviderInterface
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     protected $rules = [];
 
     /**

--- a/src/Provider/Rule/ProviderInterface.php
+++ b/src/Provider/Rule/ProviderInterface.php
@@ -1,12 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Provider\Rule;
 
 /**
  * Rule provider interface, allows specifying that an object
  * can provide ACL rules
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 interface ProviderInterface
 {

--- a/src/Service/AuthenticationIdentityProviderServiceFactory.php
+++ b/src/Service/AuthenticationIdentityProviderServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Provider\Identity\AuthenticationIdentityProvider;
@@ -8,20 +10,19 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Simple authentication provider factory
- *
- * @author Ingo Walz <ingo.walz@googlemail.com>
  */
 class AuthenticationIdentityProviderServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $user = $container->get('lmcuser_user_service');
+        $user                   = $container->get('lmcuser_user_service');
         $simpleIdentityProvider = new AuthenticationIdentityProvider($user->getAuthService());
-        $config = $container->get('BjyAuthorize\Config');
+        $config                 = $container->get('BjyAuthorize\Config');
 
         $simpleIdentityProvider->setDefaultRole($config['default_role']);
         $simpleIdentityProvider->setAuthenticatedRole($config['authenticated_role']);

--- a/src/Service/AuthorizeAwareInterface.php
+++ b/src/Service/AuthorizeAwareInterface.php
@@ -1,18 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
+
+use BjyAuthorize\Service\Authorize;
 
 /**
  * Interface for Authorize-aware objects. Allows injection
  * of an {@see \BjyAuthorize\Service\Authorize}
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 interface AuthorizeAwareInterface
 {
     /**
-     * @param \BjyAuthorize\Service\Authorize $auth
-     *
      * @return void
      */
     public function setAuthorizeService(Authorize $auth);

--- a/src/Service/AuthorizeAwareServiceInitializer.php
+++ b/src/Service/AuthorizeAwareServiceInitializer.php
@@ -1,29 +1,31 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
+use BjyAuthorize\Service\Authorize;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Initializer\InitializerInterface;
 
 /**
  * Initializer that injects a {@see \BjyAuthorize\Service\Authorize} in
  * objects that are instances of {@see \BjyAuthorize\Service\AuthorizeAwareInterface}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class AuthorizeAwareServiceInitializer implements InitializerInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Initializer\InitializerInterface::__invoke()
      */
     public function __invoke(ContainerInterface $container, $instance)
     {
-        if (!$instance instanceof AuthorizeAwareInterface) {
+        if (! $instance instanceof AuthorizeAwareInterface) {
             return;
         }
 
-        /* @var $authorize \BjyAuthorize\Service\Authorize */
+        /** @var Authorize $authorize */
         $authorize = $container->get(Authorize::class);
 
         $instance->setAuthorizeService($authorize);

--- a/src/Service/AuthorizeFactory.php
+++ b/src/Service/AuthorizeFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use Interop\Container\ContainerInterface;
@@ -7,16 +9,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of building the {@see \BjyAuthorize\Service\Authorize} service
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class AuthorizeFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new Authorize($container->get('BjyAuthorize\Config'), $container);
     }

--- a/src/Service/BaseProvidersServiceFactory.php
+++ b/src/Service/BaseProvidersServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use Interop\Container\ContainerInterface;
@@ -7,20 +9,20 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Base factory responsible of instantiating providers
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
+// phpcs:ignore WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix
 abstract class BaseProvidersServiceFactory implements FactoryInterface
 {
-    const PROVIDER_SETTING = 'providers';
+    public const PROVIDER_SETTING = 'providers';
 
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $config = $container->get('BjyAuthorize\Config');
+        $config    = $container->get('BjyAuthorize\Config');
         $providers = [];
 
         foreach ($config[static::PROVIDER_SETTING] as $providerName => $providerConfig) {

--- a/src/Service/CacheFactory.php
+++ b/src/Service/CacheFactory.php
@@ -1,24 +1,24 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use Interop\Container\ContainerInterface;
 use Laminas\Cache\StorageFactory;
-use Laminas\Cache\Storage\StorageInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory for building the cache storage
- *
- * @author Christian Bergau <cbergau86@gmail.com>
  */
 class CacheFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return StorageFactory::factory($container->get('BjyAuthorize\Config')['cache_options']);
     }

--- a/src/Service/CacheKeyGeneratorFactory.php
+++ b/src/Service/CacheKeyGeneratorFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use Interop\Container\ContainerInterface;
@@ -7,19 +9,18 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory for building a cache key generator
- *
- * @author Steve Rhoades <sedonami@gmail.com>
  */
 class CacheKeyGeneratorFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $config = $container->get('BjyAuthorize\Config');
-        $cacheKey = empty($config['cache_key']) ? 'bjyauthorize_acl' : (string)$config['cache_key'];
+        $config   = $container->get('BjyAuthorize\Config');
+        $cacheKey = empty($config['cache_key']) ? 'bjyauthorize_acl' : (string) $config['cache_key'];
 
         return function () use ($cacheKey) {
             return $cacheKey;

--- a/src/Service/ConfigResourceProviderServiceFactory.php
+++ b/src/Service/ConfigResourceProviderServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Provider\Resource\Config;
@@ -8,16 +10,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Provider\Resource\Config}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigResourceProviderServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new Config(
             $container->get('BjyAuthorize\Config')['resource_providers'][Config::class]

--- a/src/Service/ConfigRoleProviderServiceFactory.php
+++ b/src/Service/ConfigRoleProviderServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Provider\Role\Config;
@@ -8,16 +10,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Provider\Role\Config}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigRoleProviderServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new Config(
             $container->get('BjyAuthorize\Config')['role_providers'][Config::class]

--- a/src/Service/ConfigRuleProviderServiceFactory.php
+++ b/src/Service/ConfigRuleProviderServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Provider\Rule\Config;
@@ -8,16 +10,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Provider\Rule\Config}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigRuleProviderServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new Config(
             $container->get('BjyAuthorize\Config')['rule_providers'][Config::class]

--- a/src/Service/ConfigServiceFactory.php
+++ b/src/Service/ConfigServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use Interop\Container\ContainerInterface;
@@ -7,16 +9,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of retrieving an array containing the BjyAuthorize configuration
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $config = $container->get('config');
 

--- a/src/Service/ControllerGuardServiceFactory.php
+++ b/src/Service/ControllerGuardServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Guard\Controller;
@@ -8,16 +10,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Guard\Controller}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ControllerGuardServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new Controller(
             $container->get('BjyAuthorize\Config')['guards'][Controller::class],

--- a/src/Service/GuardsServiceFactory.php
+++ b/src/Service/GuardsServiceFactory.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 /**
  * Factory responsible of building a set of {@see \BjyAuthorize\Guard\GuardInterface}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class GuardsServiceFactory extends BaseProvidersServiceFactory
 {
-    const PROVIDER_SETTING = 'guards';
+    public const PROVIDER_SETTING = 'guards';
 }

--- a/src/Service/IdentityProviderServiceFactory.php
+++ b/src/Service/IdentityProviderServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use Interop\Container\ContainerInterface;
@@ -7,16 +9,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of building {@see \BjyAuthorize\Provider\Identity\ProviderInterface}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class IdentityProviderServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return $container->get($container->get('BjyAuthorize\Config')['identity_provider']);
     }

--- a/src/Service/LaminasDbRoleProviderServiceFactory.php
+++ b/src/Service/LaminasDbRoleProviderServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Provider\Role\LaminasDb;
@@ -8,16 +10,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Provider\Role\LaminasDb}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class LaminasDbRoleProviderServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new LaminasDb(
             $container->get('BjyAuthorize\Config')['role_providers'][LaminasDb::class],

--- a/src/Service/LmcUserLaminasDbIdentityProviderServiceFactory.php
+++ b/src/Service/LmcUserLaminasDbIdentityProviderServiceFactory.php
@@ -1,30 +1,32 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Provider\Identity\LmcUserLaminasDb;
 use Interop\Container\ContainerInterface;
 use Laminas\Db\TableGateway\TableGateway;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use LmcUser\Service\User;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Provider\Identity\LmcUserLaminasDb}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class LmcUserLaminasDbIdentityProviderServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /* @var $tableGateway \Laminas\Db\TableGateway\TableGateway */
+        /** @var TableGateway $tableGateway */
         $tableGateway = new TableGateway('user_role_linker', $container->get('lmcuser_laminas_db_adapter'));
-        /* @var $userService \LmcUser\Service\User */
+        /** @var User $userService */
         $userService = $container->get('lmcuser_user_service');
-        $config = $container->get('BjyAuthorize\Config');
+        $config      = $container->get('BjyAuthorize\Config');
 
         $provider = new LmcUserLaminasDb($tableGateway, $userService);
 

--- a/src/Service/ObjectRepositoryRoleProviderFactory.php
+++ b/src/Service/ObjectRepositoryRoleProviderFactory.php
@@ -1,29 +1,30 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Exception\InvalidArgumentException;
 use BjyAuthorize\Provider\Role\ObjectRepositoryProvider;
+use Doctrine\Persistence\ObjectManager;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Provider\Role\ObjectRepositoryProvider}
- *
- * @author Tom Oram <tom@scl.co.uk>
- * @author Jérémy Huet <jeremy.huet@gmail.com>
  */
 class ObjectRepositoryRoleProviderFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         $config = $container->get('BjyAuthorize\Config');
 
-        if (!isset($config['role_providers'][ObjectRepositoryProvider::class])) {
+        if (! isset($config['role_providers'][ObjectRepositoryProvider::class])) {
             throw new InvalidArgumentException(
                 'Config for "BjyAuthorize\Provider\Role\ObjectRepositoryProvider" not set'
             );
@@ -31,15 +32,15 @@ class ObjectRepositoryRoleProviderFactory implements FactoryInterface
 
         $providerConfig = $config['role_providers'][ObjectRepositoryProvider::class];
 
-        if (!isset($providerConfig['role_entity_class'])) {
+        if (! isset($providerConfig['role_entity_class'])) {
             throw new InvalidArgumentException('role_entity_class not set in the bjyauthorize role_providers config.');
         }
 
-        if (!isset($providerConfig['object_manager'])) {
+        if (! isset($providerConfig['object_manager'])) {
             throw new InvalidArgumentException('object_manager not set in the bjyauthorize role_providers config.');
         }
 
-        /* @var $objectManager \Doctrine\Persistence\ObjectManager */
+        /** @var ObjectManager $objectManager */
         $objectManager = $container->get($providerConfig['object_manager']);
 
         return new ObjectRepositoryProvider($objectManager->getRepository($providerConfig['role_entity_class']));

--- a/src/Service/ResourceProvidersServiceFactory.php
+++ b/src/Service/ResourceProvidersServiceFactory.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 /**
  * Factory responsible of a set of {@see \BjyAuthorize\Provider\Resource\ProviderInterface}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ResourceProvidersServiceFactory extends BaseProvidersServiceFactory
 {
-    const PROVIDER_SETTING = 'resource_providers';
+    public const PROVIDER_SETTING = 'resource_providers';
 }

--- a/src/Service/RoleCollectorServiceFactory.php
+++ b/src/Service/RoleCollectorServiceFactory.php
@@ -1,26 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Collector\RoleCollector;
+use BjyAuthorize\Provider\Identity\ProviderInterface;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Collector\RoleCollector}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RoleCollectorServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /* @var $identityProvider \BjyAuthorize\Provider\Identity\ProviderInterface */
-        $identityProvider = $container->get('BjyAuthorize\Provider\Identity\ProviderInterface');
+        /** @var ProviderInterface $identityProvider */
+        $identityProvider = $container->get(ProviderInterface::class);
 
         return new RoleCollector($identityProvider);
     }

--- a/src/Service/RoleProvidersServiceFactory.php
+++ b/src/Service/RoleProvidersServiceFactory.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 /**
  * Factory responsible of a set of {@see \BjyAuthorize\Provider\Role\ProviderInterface}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RoleProvidersServiceFactory extends BaseProvidersServiceFactory
 {
-    const PROVIDER_SETTING = 'role_providers';
+    public const PROVIDER_SETTING = 'role_providers';
 }

--- a/src/Service/RouteGuardServiceFactory.php
+++ b/src/Service/RouteGuardServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\Guard\Route;
@@ -8,16 +10,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\Guard\Route}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RouteGuardServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new Route($container->get('BjyAuthorize\Config')['guards'][Route::class], $container);
     }

--- a/src/Service/RuleProvidersServiceFactory.php
+++ b/src/Service/RuleProvidersServiceFactory.php
@@ -1,13 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 /**
  * Factory responsible of a set of {@see \BjyAuthorize\Provider\Rule\ProviderInterface}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RuleProvidersServiceFactory extends BaseProvidersServiceFactory
 {
-    const PROVIDER_SETTING = 'rule_providers';
+    public const PROVIDER_SETTING = 'rule_providers';
 }

--- a/src/Service/UnauthorizedStrategyServiceFactory.php
+++ b/src/Service/UnauthorizedStrategyServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use BjyAuthorize\View\UnauthorizedStrategy;
@@ -8,16 +10,15 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory responsible of instantiating {@see \BjyAuthorize\View\UnauthorizedStrategy}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class UnauthorizedStrategyServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new UnauthorizedStrategy($container->get('BjyAuthorize\Config')['template']);
     }

--- a/src/Service/UserRoleServiceFactory.php
+++ b/src/Service/UserRoleServiceFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\Service;
 
 use Interop\Container\ContainerInterface;
@@ -7,17 +9,16 @@ use Laminas\Db\TableGateway\TableGateway;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
- * @author Simone Castellaneta <s.castel@gmail.com>
- *
- * @return \Laminas\Db\TableGateway\TableGateway
+ * @return TableGateway
  */
 class UserRoleServiceFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}
+     *
      * @see \Laminas\ServiceManager\Factory\FactoryInterface::__invoke()
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         return new TableGateway('user_role', $container->get('bjyauthorize_zend_db_adapter'));
     }

--- a/src/View/Helper/IsAllowed.php
+++ b/src/View/Helper/IsAllowed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\View\Helper;
 
 use BjyAuthorize\Service\Authorize;
@@ -7,19 +9,12 @@ use Laminas\View\Helper\AbstractHelper;
 
 /**
  * IsAllowed View helper. Allows checking access to a resource/privilege in views.
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class IsAllowed extends AbstractHelper
 {
-    /**
-     * @var Authorize
-     */
+    /** @var Authorize */
     protected $authorizeService;
 
-    /**
-     * @param Authorize $authorizeService
-     */
     public function __construct(Authorize $authorizeService)
     {
         $this->authorizeService = $authorizeService;
@@ -28,7 +23,6 @@ class IsAllowed extends AbstractHelper
     /**
      * @param mixed $resource
      * @param mixed|null $privilege
-     *
      * @return bool
      */
     public function __invoke($resource, $privilege = null)

--- a/src/View/Helper/IsAllowedFactory.php
+++ b/src/View/Helper/IsAllowedFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\View\Helper;
 
 use BjyAuthorize\Service\Authorize;
@@ -20,14 +22,13 @@ class IsAllowedFactory implements FactoryInterface
     }
 
     /**
-     * @param ContainerInterface $container
      * @param string $requestedName
      * @param array|null $options
      * @return IsAllowed
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        /* @var $authorize \BjyAuthorize\Service\Authorize */
+        /** @var Authorize $authorize */
         $authorize = $container->get(Authorize::class);
 
         return new IsAllowed($authorize);

--- a/src/View/RedirectionStrategy.php
+++ b/src/View/RedirectionStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\View;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
@@ -14,25 +16,16 @@ use Laminas\Mvc\MvcEvent;
 /**
  * Dispatch error handler, catches exceptions related with authorization and
  * redirects the user agent to a configured location
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
- * @author Marco Pivetta  <ocramius@gmail.com>
  */
 class RedirectionStrategy implements ListenerAggregateInterface
 {
-    /**
-     * @var string route to be used to handle redirects
-     */
+    /** @var string route to be used to handle redirects */
     protected $redirectRoute = 'lmcuser/login';
 
-    /**
-     * @var string URI to be used to handle redirects
-     */
+    /** @var string URI to be used to handle redirects */
     protected $redirectUri;
 
-    /**
-     * @var callable[] An array with callback functions or methods.
-     */
+    /** @var callable[] An array with callback functions or methods. */
     protected $listeners = [];
 
     /**
@@ -57,28 +50,27 @@ class RedirectionStrategy implements ListenerAggregateInterface
 
     /**
      * Handles redirects in case of dispatch errors caused by unauthorized access
-     *
-     * @param \Laminas\Mvc\MvcEvent $event
      */
     public function onDispatchError(MvcEvent $event)
     {
         // Do nothing if the result is a response object
-        $result = $event->getResult();
+        $result     = $event->getResult();
         $routeMatch = $event->getRouteMatch();
-        $response = $event->getResponse();
-        $router = $event->getRouter();
-        $error = $event->getError();
-        $url = $this->redirectUri;
+        $response   = $event->getResponse();
+        $router     = $event->getRouter();
+        $error      = $event->getError();
+        $url        = $this->redirectUri;
 
-        if ($result instanceof Response
-            || !$routeMatch
-            || ($response && !$response instanceof Response)
-            || !(
+        if (
+            $result instanceof Response
+            || ! $routeMatch
+            || ($response && ! $response instanceof Response)
+            || ! (
                 Route::ERROR === $error
                 || Controller::ERROR === $error
                 || (
                     Application::ERROR_EXCEPTION === $error
-                    && ($event->getParam('exception') instanceof UnAuthorizedException)
+                    && $event->getParam('exception') instanceof UnAuthorizedException
                 )
             )
         ) {
@@ -102,7 +94,7 @@ class RedirectionStrategy implements ListenerAggregateInterface
      */
     public function setRedirectRoute($redirectRoute)
     {
-        $this->redirectRoute = (string)$redirectRoute;
+        $this->redirectRoute = (string) $redirectRoute;
     }
 
     /**
@@ -110,6 +102,6 @@ class RedirectionStrategy implements ListenerAggregateInterface
      */
     public function setRedirectUri($redirectUri)
     {
-        $this->redirectUri = $redirectUri ? (string)$redirectUri : null;
+        $this->redirectUri = $redirectUri ? (string) $redirectUri : null;
     }
 }

--- a/src/View/UnauthorizedStrategy.php
+++ b/src/View/UnauthorizedStrategy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorize\View;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
@@ -16,19 +18,13 @@ use Laminas\View\Model\ViewModel;
 /**
  * Dispatch error handler, catches exceptions related with authorization and
  * configures the application response accordingly.
- *
- * @author Ben Youngblood <bx.youngblood@gmail.com>
  */
 class UnauthorizedStrategy implements ListenerAggregateInterface
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $template;
 
-    /**
-     * @var callable[] An array with callback functions or methods.
-     */
+    /** @var callable[] An array with callback functions or methods. */
     protected $listeners = [];
 
     /**
@@ -36,7 +32,7 @@ class UnauthorizedStrategy implements ListenerAggregateInterface
      */
     public function __construct($template)
     {
-        $this->template = (string)$template;
+        $this->template = (string) $template;
     }
 
     /**
@@ -64,7 +60,7 @@ class UnauthorizedStrategy implements ListenerAggregateInterface
      */
     public function setTemplate($template)
     {
-        $this->template = (string)$template;
+        $this->template = (string) $template;
     }
 
     /**
@@ -80,41 +76,39 @@ class UnauthorizedStrategy implements ListenerAggregateInterface
      * response object with an according error if the application
      * event contains an exception related with authorization.
      *
-     * @param MvcEvent $event
-     *
      * @return void
      */
     public function onDispatchError(MvcEvent $event)
     {
         // Do nothing if the result is a response object
-        $result = $event->getResult();
+        $result   = $event->getResult();
         $response = $event->getResponse();
 
-        if ($result instanceof Response || ($response && !$response instanceof HttpResponse)) {
+        if ($result instanceof Response || ($response && ! $response instanceof HttpResponse)) {
             return;
         }
 
         // Common view variables
         $viewVariables = [
-            'error' => $event->getParam('error'),
+            'error'    => $event->getParam('error'),
             'identity' => $event->getParam('identity'),
         ];
 
         switch ($event->getError()) {
             case Controller::ERROR:
                 $viewVariables['controller'] = $event->getParam('controller');
-                $viewVariables['action'] = $event->getParam('action');
+                $viewVariables['action']     = $event->getParam('action');
                 break;
             case Route::ERROR:
                 $viewVariables['route'] = $event->getParam('route');
                 break;
             case Application::ERROR_EXCEPTION:
-                if (!($event->getParam('exception') instanceof UnAuthorizedException)) {
+                if (! $event->getParam('exception') instanceof UnAuthorizedException) {
                     return;
                 }
 
                 $viewVariables['reason'] = $event->getParam('exception')->getMessage();
-                $viewVariables['error'] = 'error-unauthorized';
+                $viewVariables['error']  = 'error-unauthorized';
                 break;
             default:
                 /*
@@ -126,7 +120,7 @@ class UnauthorizedStrategy implements ListenerAggregateInterface
                 return;
         }
 
-        $model = new ViewModel($viewVariables);
+        $model    = new ViewModel($viewVariables);
         $response = $response ?: new HttpResponse();
 
         $model->setTemplate($this->getTemplate());

--- a/test/Acl/RoleTest.php
+++ b/test/Acl/RoleTest.php
@@ -1,15 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Acl;
 
-use \PHPUnit\Framework\TestCase;
 use BjyAuthorize\Acl\Role;
+use BjyAuthorize\Exception\InvalidRoleException;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * Base role object tests
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RoleTest extends TestCase
 {
@@ -85,7 +86,7 @@ class RoleTest extends TestCase
     {
         $role = new Role('test1');
 
-        $this->expectException('BjyAuthorize\Exception\InvalidRoleException');
+        $this->expectException(InvalidRoleException::class);
         $role->setParent(new stdClass());
     }
 }

--- a/test/Collector/RoleCollectorTest.php
+++ b/test/Collector/RoleCollectorTest.php
@@ -1,25 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Collector;
 
+use ArrayIterator;
 use BjyAuthorize\Collector\RoleCollector;
-use \PHPUnit\Framework\TestCase;
+use BjyAuthorize\Provider\Identity\ProviderInterface;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Permissions\Acl\Role\RoleInterface;
+use PHPUnit\Framework\TestCase;
+
+use function serialize;
+use function unserialize;
 
 /**
  * Tests for {@see \BjyAuthorize\Collector\RoleCollector}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RoleCollectorTest extends TestCase
 {
-    /**
-     * @var \BjyAuthorize\Collector\RoleCollector
-     */
+    /** @var RoleCollector */
     protected $collector;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\BjyAuthorize\Provider\Identity\ProviderInterface
-     */
+    /** @var MockObject|ProviderInterface */
     protected $identityProvider;
 
     /**
@@ -29,7 +32,7 @@ class RoleCollectorTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->identityProvider = $this->createMock('BjyAuthorize\\Provider\\Identity\\ProviderInterface');
+        $this->identityProvider = $this->createMock(ProviderInterface::class);
         $this->collector        = new RoleCollector($this->identityProvider);
     }
 
@@ -41,8 +44,8 @@ class RoleCollectorTest extends TestCase
      */
     public function testCollect()
     {
-        $role1    = $this->createMock('Laminas\\Permissions\\Acl\\Role\\RoleInterface');
-        $mvcEvent = $this->createMock('Laminas\\Mvc\\MvcEvent');
+        $role1    = $this->createMock(RoleInterface::class);
+        $mvcEvent = $this->createMock(MvcEvent::class);
 
         $role1->expects($this->any())->method('getRoleId')->will($this->returnValue('role1'));
 
@@ -53,9 +56,9 @@ class RoleCollectorTest extends TestCase
             ->will(
                 $this->returnValue(
                     [
-                         $role1,
-                         'role2',
-                         'key' => 'role3',
+                        $role1,
+                        'role2',
+                        'key' => 'role3',
                     ]
                 )
             );
@@ -69,7 +72,7 @@ class RoleCollectorTest extends TestCase
         $this->assertContains('role2', $roles);
         $this->assertContains('role3', $roles);
 
-        /* @var $collector \BjyAuthorize\Collector\RoleCollector */
+        /** @var RoleCollector $collector */
         $collector = unserialize(serialize($this->collector));
 
         $collector->collect($mvcEvent);
@@ -88,8 +91,8 @@ class RoleCollectorTest extends TestCase
      */
     public function testTraversableCollect()
     {
-        $role1    = $this->createMock('Laminas\\Permissions\\Acl\\Role\\RoleInterface');
-        $mvcEvent = $this->createMock('Laminas\\Mvc\\MvcEvent');
+        $role1    = $this->createMock(RoleInterface::class);
+        $mvcEvent = $this->createMock(MvcEvent::class);
 
         $role1->expects($this->any())->method('getRoleId')->will($this->returnValue('role1'));
 
@@ -99,7 +102,7 @@ class RoleCollectorTest extends TestCase
             ->method('getIdentityRoles')
             ->will(
                 $this->returnValue(
-                    new \ArrayIterator(
+                    new ArrayIterator(
                         [
                             $role1,
                             'role2',

--- a/test/Controller/Plugin/IsAllowedTest.php
+++ b/test/Controller/Plugin/IsAllowedTest.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Controller\Plugin;
 
-use \PHPUnit\Framework\TestCase;
 use BjyAuthorize\Controller\Plugin\IsAllowed;
+use BjyAuthorize\Service\Authorize;
+use PHPUnit\Framework\TestCase;
 
 /**
  * IsAllowed controller plugin test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class IsAllowedTest extends TestCase
 {
@@ -17,7 +18,7 @@ class IsAllowedTest extends TestCase
      */
     public function testIsAllowed()
     {
-        $authorize = $this->getMockBuilder('BjyAuthorize\\Service\\Authorize')->disableOriginalConstructor()->getMock();
+        $authorize = $this->getMockBuilder(Authorize::class)->disableOriginalConstructor()->getMock();
         $authorize
             ->expects($this->once())
             ->method('isAllowed')
@@ -27,7 +28,7 @@ class IsAllowedTest extends TestCase
         $plugin = new IsAllowed($authorize);
         $this->assertTrue($plugin->__invoke('test', 'privilege'));
 
-        $authorize2 = $this->getMockBuilder('BjyAuthorize\\Service\\Authorize')->disableOriginalConstructor()->getMock();
+        $authorize2 = $this->getMockBuilder(Authorize::class)->disableOriginalConstructor()->getMock();
         $authorize2
             ->expects($this->once())
             ->method('isAllowed')

--- a/test/Guard/ControllerTest.php
+++ b/test/Guard/ControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Guard;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
@@ -13,28 +15,21 @@ use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Controller Guard test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ControllerTest extends TestCase
 {
-    /**
-     * @var \Laminas\ServiceManager\ServiceLocatorInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var ServiceLocatorInterface|MockObject */
     protected $serviceLocator;
 
-    /**
-     * @var \BjyAuthorize\Service\Authorize|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var Authorize|MockObject */
     protected $authorize;
 
-    /**
-     * @var Controller
-     */
+    /** @var Controller */
     protected $controllerGuard;
 
     /**
@@ -47,7 +42,7 @@ class ControllerTest extends TestCase
         parent::setUp();
 
         $this->serviceLocator  = $locator = $this->createMock(ServiceLocatorInterface::class);
-        $this->authorize = $authorize = $this->getMockBuilder(Authorize::class)
+        $this->authorize       = $authorize = $this->getMockBuilder(Authorize::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controllerGuard = new Controller([], $this->serviceLocator);
@@ -92,11 +87,9 @@ class ControllerTest extends TestCase
 
     /**
      * @dataProvider controllersRulesProvider
-     *
      * @covers \BjyAuthorize\Guard\Controller::__construct
      * @covers \BjyAuthorize\Guard\Controller::getResources
      * @covers \BjyAuthorize\Guard\Controller::getRules
-     *
      * @param array     $rule
      * @param int       $expectedCount
      * @param string    $resource
@@ -119,10 +112,8 @@ class ControllerTest extends TestCase
 
     /**
      * @dataProvider controllersRulesWithAssertionProvider
-     *
      * @covers \BjyAuthorize\Guard\Controller::__construct
      * @covers \BjyAuthorize\Guard\Controller::getRules
-     *
      * @param array     $rule
      * @param int       $expectedCount
      * @param string    $resource
@@ -272,13 +263,13 @@ class ControllerTest extends TestCase
      */
     public function testOnDispatchWithInvalidResourceConsole()
     {
-        $event = $this->getMockBuilder(MvcEvent::class)
+        $event      = $this->getMockBuilder(MvcEvent::class)
             ->disableOriginalConstructor()
             ->getMock();
         $routeMatch = $this->getMockBuilder(RouteMatch::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $request = $this->getMockBuilder(ConsoleRequest::class)
+        $request    = $this->getMockBuilder(ConsoleRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
         $event->method('getRouteMatch')->willReturn($routeMatch);
@@ -291,22 +282,21 @@ class ControllerTest extends TestCase
      * @param string|null $controller
      * @param string|null $action
      * @param string|null $method
-     *
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Laminas\Mvc\MvcEvent
+     * @return MockObject|MvcEvent
      */
     private function createMvcEvent($controller = null, $action = null, $method = null)
     {
         $eventManager = $this->getMockBuilder(EventManagerInterface::class)
             ->getMock();
-        $application = $this->getMockBuilder(Application::class)
+        $application  = $this->getMockBuilder(Application::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $event = $this->getMockBuilder(MvcEvent::class)
+        $event        = $this->getMockBuilder(MvcEvent::class)
             ->getMock();
-        $routeMatch = $this->getMockBuilder(RouteMatch::class)
+        $routeMatch   = $this->getMockBuilder(RouteMatch::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $request = $this->getMockBuilder(HttpRequest::class)
+        $request      = $this->getMockBuilder(HttpRequest::class)
             ->getMock();
 
         $event->expects($this->any())->method('getRouteMatch')->will($this->returnValue($routeMatch));
@@ -356,7 +346,7 @@ class ControllerTest extends TestCase
                 ],
                 1,
                 'controller/test-controller:test-action',
-                ['admin', 'user']
+                ['admin', 'user'],
             ],
             [
                 [
@@ -368,17 +358,17 @@ class ControllerTest extends TestCase
                 ],
                 1,
                 'controller/test2-controller',
-                ['admin2', 'user2']
+                ['admin2', 'user2'],
             ],
             [
                 [
                     'controller' => 'test3-controller',
                     'action'     => 'test3-action',
-                    'roles'      => 'admin3'
+                    'roles'      => 'admin3',
                 ],
                 1,
                 'controller/test3-controller:test3-action',
-                ['admin3']
+                ['admin3'],
             ],
             [
                 [
@@ -394,7 +384,7 @@ class ControllerTest extends TestCase
                 ],
                 2,
                 'controller/test4-controller:test4-action',
-                ['admin4', 'user3']
+                ['admin4', 'user3'],
             ],
             [
                 [
@@ -410,17 +400,17 @@ class ControllerTest extends TestCase
                 ],
                 2,
                 'controller/test4-controller:test5-action',
-                ['admin4', 'user3']
+                ['admin4', 'user3'],
             ],
             [
                 [
                     'controller' => 'test5-controller',
                     'action'     => null,
-                    'roles'      => 'user4'
+                    'roles'      => 'user4',
                 ],
                 1,
                 'controller/test5-controller',
-                ['user4']
+                ['user4'],
             ],
             [
                 [
@@ -429,11 +419,11 @@ class ControllerTest extends TestCase
                         'test7-controller',
                     ],
                     'action'     => null,
-                    'roles'      => 'user5'
+                    'roles'      => 'user5',
                 ],
                 2,
                 'controller/test6-controller',
-                ['user5']
+                ['user5'],
             ],
             [
                 [
@@ -442,11 +432,11 @@ class ControllerTest extends TestCase
                         'test7-controller',
                     ],
                     'action'     => null,
-                    'roles'      => 'user5'
+                    'roles'      => 'user5',
                 ],
                 2,
                 'controller/test7-controller',
-                ['user5']
+                ['user5'],
             ],
             [
                 [
@@ -465,7 +455,7 @@ class ControllerTest extends TestCase
                 ],
                 4,
                 'controller/test6-controller:test6-action',
-                ['admin5', 'user6']
+                ['admin5', 'user6'],
             ],
             [
                 [
@@ -484,8 +474,8 @@ class ControllerTest extends TestCase
                 ],
                 4,
                 'controller/test7-controller:test7-action',
-                ['admin5', 'user6']
-            ]
+                ['admin5', 'user6'],
+            ],
         ];
     }
 
@@ -506,12 +496,12 @@ class ControllerTest extends TestCase
                         'admin',
                         'user',
                     ],
-                    'assertion' => 'test-assertion'
+                    'assertion'  => 'test-assertion',
                 ],
                 1,
                 'controller/test-controller:test-action',
                 ['admin', 'user'],
-                'test-assertion'
+                'test-assertion',
             ],
             [
                 [
@@ -527,13 +517,13 @@ class ControllerTest extends TestCase
                         'admin5',
                         'user6',
                     ],
-                    'assertion' => 'test-assertion'
+                    'assertion'  => 'test-assertion',
                 ],
                 4,
                 'controller/test6-controller:test6-action',
                 ['admin5', 'user6'],
-                'test-assertion'
-            ]
+                'test-assertion',
+            ],
         ];
     }
 }

--- a/test/Guard/RouteTest.php
+++ b/test/Guard/RouteTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Guard;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
@@ -13,28 +15,21 @@ use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Route Guard test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RouteTest extends TestCase
 {
-    /**
-     * @var \Laminas\ServiceManager\ServiceLocatorInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var ServiceLocatorInterface|MockObject */
     protected $serviceLocator;
 
-    /**
-     * @var \BjyAuthorize\Service\Authorize|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var Authorize|MockObject */
     protected $authorize;
 
-    /**
-     * @var Route
-     */
+    /** @var Route */
     protected $routeGuard;
 
     /**
@@ -48,10 +43,10 @@ class RouteTest extends TestCase
 
         $this->serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
             ->getMock();
-        $this->authorize = $authorize = $this->getMockBuilder(Authorize::class)
+        $this->authorize      = $authorize = $this->getMockBuilder(Authorize::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->routeGuard = new Route([], $this->serviceLocator);
+        $this->routeGuard     = new Route([], $this->serviceLocator);
 
         $this
             ->serviceLocator
@@ -98,24 +93,24 @@ class RouteTest extends TestCase
     {
         $controller = new Route(
             [
-                 [
-                     'route' => 'test/route',
-                     'roles' => [
-                         'admin',
-                         'user',
-                     ],
-                 ],
-                 [
-                     'route' => 'test2-route',
-                     'roles' => [
-                         'admin2',
-                         'user2',
-                     ],
-                 ],
-                 [
-                     'route' => 'test3-route',
-                     'roles' => 'admin3'
-                 ],
+                [
+                    'route' => 'test/route',
+                    'roles' => [
+                        'admin',
+                        'user',
+                    ],
+                ],
+                [
+                    'route' => 'test2-route',
+                    'roles' => [
+                        'admin2',
+                        'user2',
+                    ],
+                ],
+                [
+                    'route' => 'test3-route',
+                    'roles' => 'admin3',
+                ],
             ],
             $this->serviceLocator
         );
@@ -152,14 +147,14 @@ class RouteTest extends TestCase
     {
         $controller = new Route(
             [
-                 [
-                     'route' => 'test/route',
-                     'roles' => [
-                         'admin',
-                         'user',
-                     ],
-                     'assertion' => 'test-assertion'
-                 ],
+                [
+                    'route'     => 'test/route',
+                    'roles'     => [
+                        'admin',
+                        'user',
+                    ],
+                    'assertion' => 'test-assertion',
+                ],
             ],
             $this->serviceLocator
         );
@@ -235,12 +230,12 @@ class RouteTest extends TestCase
      */
     public function testOnDispatchWithInvalidResourceConsole()
     {
-        $event = $this->getMockBuilder(MvcEvent::class)
+        $event      = $this->getMockBuilder(MvcEvent::class)
             ->getMock();
         $routeMatch = $this->getMockBuilder(RouteMatch::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $request = $this->getMockBuilder(ConsoleRequest::class)
+        $request    = $this->getMockBuilder(ConsoleRequest::class)
             ->disableOriginalConstructor()
             ->getMock();
         $event->method('getRouteMatch')->willReturn($routeMatch);
@@ -251,22 +246,21 @@ class RouteTest extends TestCase
 
     /**
      * @param string|null $route
-     *
-     * @return \PHPUnit\Framework\MockObject\MockObject|\Laminas\Mvc\MvcEvent
+     * @return MockObject|MvcEvent
      */
     private function createMvcEvent($route = null)
     {
         $eventManager = $this->getMockBuilder(EventManagerInterface::class)
             ->getMock();
-        $application = $this->getMockBuilder(Application::class)
+        $application  = $this->getMockBuilder(Application::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $event = $this->getMockBuilder(MvcEvent::class)
+        $event        = $this->getMockBuilder(MvcEvent::class)
             ->getMock();
-        $routeMatch = $this->getMockBuilder(RouteMatch::class)
+        $routeMatch   = $this->getMockBuilder(RouteMatch::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $request = $this->getMockBuilder(HttpRequest::class)
+        $request      = $this->getMockBuilder(HttpRequest::class)
             ->getMock();
 
         $event->expects($this->any())->method('getRouteMatch')->will($this->returnValue($routeMatch));

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest;
 
 use BjyAuthorize\Guard\Controller;
 use BjyAuthorize\Guard\Route;
 use BjyAuthorize\Module;
 use BjyAuthorize\View\UnauthorizedStrategy;
+use InvalidArgumentException;
 use Laminas\EventManager\EventManager;
 use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
@@ -31,11 +34,14 @@ class ModuleTest extends TestCase
     public function testIfBoostrapRegistersGuardsAndStrategy()
     {
         $module = new Module();
-        $event = $this->getMockedBootstrapEvent();
+        $event  = $this->getMockedBootstrapEvent();
 
         $module->onBootstrap($event);
     }
 
+    /**
+     * @return MvcEvent
+     */
     protected function getMockedBootstrapEvent()
     {
         $guard1 = $this->getMockBuilder(Controller::class)
@@ -64,7 +70,7 @@ class ModuleTest extends TestCase
 
         $serviceManager->expects($this->any())
             ->method('get')
-            ->will($this->returnCallback(function(string $name) use ($guard1, $guard2, $strategy) {
+            ->will($this->returnCallback(function (string $name) use ($guard1, $guard2, $strategy) {
                 switch ($name) {
                     case 'BjyAuthorize\Config':
                         return ['unauthorized_strategy' => 'my_unauthorized_strategy'];
@@ -73,7 +79,7 @@ class ModuleTest extends TestCase
                     case 'BjyAuthorize\Guards':
                         return [$guard1, $guard2];
                     default:
-                        throw new \InvalidArgumentException('Invalid service call.');
+                        throw new InvalidArgumentException('Invalid service call.');
                 }
             }));
 

--- a/test/Provider/Identity/AuthenticationIdentityProviderTest.php
+++ b/test/Provider/Identity/AuthenticationIdentityProviderTest.php
@@ -1,29 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Provider\Identity;
 
-use BjyAuthorize\Provider\Identity\AuthenticationIdentityProvider;
-use Laminas\Authentication\AuthenticationService;
-use PHPUnit\Framework\TestCase;
-use Laminas\Permissions\Acl\Role\RoleInterface;
-use BjyAuthorize\Provider\Role\ProviderInterface;
 use BjyAuthorize\Exception\InvalidRoleException;
+use BjyAuthorize\Provider\Identity\AuthenticationIdentityProvider;
+use BjyAuthorize\Provider\Role\ProviderInterface;
+use Laminas\Authentication\AuthenticationService;
+use Laminas\Permissions\Acl\Role\RoleInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * {@see \BjyAuthorize\Provider\Identity\AuthenticationIdentityProvider} test
- *
- * @author Ingo Walz <ingo.walz@googlemail.com>
  */
 class AuthenticationIdentityProviderTest extends TestCase
 {
-    /**
-     * @var \Laminas\Authentication\AuthenticationService|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var AuthenticationService|MockObject */
     protected $authService;
 
-    /**
-     * @var \BjyAuthorize\Provider\Identity\AuthenticationIdentityProvider
-     */
+    /** @var AuthenticationIdentityProvider */
     protected $provider;
 
     /**
@@ -34,7 +31,7 @@ class AuthenticationIdentityProviderTest extends TestCase
     protected function setUp(): void
     {
         $this->authService = $this->createMock(AuthenticationService::class);
-        $this->provider = new AuthenticationIdentityProvider($this->authService);
+        $this->provider    = new AuthenticationIdentityProvider($this->authService);
     }
 
     /**
@@ -98,7 +95,7 @@ class AuthenticationIdentityProviderTest extends TestCase
     {
         $role1 = $this->createMock(RoleInterface::class);
         $role2 = $this->createMock(RoleInterface::class);
-        $user = $this->createMock(ProviderInterface::class);
+        $user  = $this->createMock(ProviderInterface::class);
 
         $user->expects($this->once())
             ->method('getRoles')

--- a/test/Provider/Identity/LmcUserLaminasDbTest.php
+++ b/test/Provider/Identity/LmcUserLaminasDbTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Provider\Identity;
 
 use BjyAuthorize\Exception\InvalidRoleException;
@@ -8,33 +10,24 @@ use Laminas\Authentication\AuthenticationService;
 use Laminas\Db\TableGateway\TableGateway;
 use Laminas\Permissions\Acl\Role\RoleInterface;
 use LmcUser\Service\User;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
  * {@see \BjyAuthorize\Provider\Identity\LmcUserLaminasDb} test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class LmcUserLaminasDbTest extends TestCase
 {
-    /**
-     * @var \Laminas\Authentication\AuthenticationService|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var AuthenticationService|MockObject */
     protected $authService;
 
-    /**
-     * @var \LmcUser\Service\User|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var User|MockObject */
     protected $userService;
 
-    /**
-     * @var \Laminas\Db\TableGateway\TableGateway|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var TableGateway|MockObject */
     private $tableGateway;
 
-    /**
-     * @var \BjyAuthorize\Provider\Identity\LmcUserLaminasDb
-     */
+    /** @var LmcUserLaminasDb */
     protected $provider;
 
     /**
@@ -44,8 +37,8 @@ class LmcUserLaminasDbTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->authService = $this->createMock(AuthenticationService::class);
-        $this->userService = $this->getMockBuilder(User::class)->getMock();
+        $this->authService  = $this->createMock(AuthenticationService::class);
+        $this->userService  = $this->getMockBuilder(User::class)->getMock();
         $this->tableGateway = $this->getMockBuilder(TableGateway::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/test/Provider/Resource/ConfigTest.php
+++ b/test/Provider/Resource/ConfigTest.php
@@ -1,14 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Provider\Resource;
 
-use \PHPUnit\Framework\TestCase;
 use BjyAuthorize\Provider\Resource\Config;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Config resource provider test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigTest extends TestCase
 {
@@ -18,7 +18,7 @@ class ConfigTest extends TestCase
      */
     public function testGetResources()
     {
-        $config = new Config(['resource1', 'resource2',]);
+        $config = new Config(['resource1', 'resource2']);
 
         $resources = $config->getResources();
 

--- a/test/Provider/Role/ConfigTest.php
+++ b/test/Provider/Role/ConfigTest.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Provider\Role;
 
-use \PHPUnit\Framework\TestCase;
+use BjyAuthorize\Acl\Role;
 use BjyAuthorize\Provider\Role\Config;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Config resource provider test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigTest extends TestCase
 {
@@ -39,9 +40,9 @@ class ConfigTest extends TestCase
 
         $this->assertCount(7, $roles);
 
-        /* @var $role \BjyAuthorize\Acl\Role */
+        /** @var Role $role */
         foreach ($roles as $role) {
-            $this->assertInstanceOf('BjyAuthorize\Acl\Role', $role);
+            $this->assertInstanceOf(Role::class, $role);
             $this->assertContains(
                 $role->getRoleId(),
                 ['role1', 'role2', 'role3', 'role4', 'role5', 'role6', 'role7']

--- a/test/Provider/Role/LaminasDbTest.php
+++ b/test/Provider/Role/LaminasDbTest.php
@@ -1,31 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Provider\Role;
 
 use BjyAuthorize\Acl\Role;
 use BjyAuthorize\Provider\Role\LaminasDb;
-use \PHPUnit\Framework\TestCase;
+use BjyAuthorize\Provider\Role\ObjectRepositoryProvider;
+use Laminas\Db\TableGateway\TableGateway;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
 /**
  * {@see \BjyAuthorize\Provider\Role\LaminasDb} test
- *
- * @author Tom Oram <tom@scl.co.uk>
  */
 class LaminasDbTest extends TestCase
 {
-    /**
-     * @var \BjyAuthorize\Provider\Role\ObjectRepositoryProvider
-     */
+    /** @var ObjectRepositoryProvider */
     private $provider;
 
-    /**
-     * @var \Laminas\ServiceManager\ServiceLocatorInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var ServiceLocatorInterface|MockObject */
     private $serviceLocator;
 
-    /**
-     * @var \Laminas\Db\TableGateway\TableGateway|\PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var TableGateway|MockObject */
     private $tableGateway;
 
     /**
@@ -33,9 +31,9 @@ class LaminasDbTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->serviceLocator = $this->createMock('Laminas\ServiceManager\ServiceLocatorInterface');
+        $this->serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $this->provider       = new LaminasDb([], $this->serviceLocator);
-        $this->tableGateway   = $this->getMockBuilder('Laminas\Db\TableGateway\TableGateway')
+        $this->tableGateway   = $this->getMockBuilder(TableGateway::class)
                                      ->disableOriginalConstructor()
                                      ->getMock();
     }

--- a/test/Provider/Role/ObjectRepositoryProviderTest.php
+++ b/test/Provider/Role/ObjectRepositoryProviderTest.php
@@ -1,27 +1,26 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Provider\Role;
 
+use BjyAuthorize\Acl\HierarchicalRoleInterface;
 use BjyAuthorize\Acl\Role;
 use BjyAuthorize\Provider\Role\ObjectRepositoryProvider;
 use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * {@see \BjyAuthorize\Provider\Role\ObjectRepositoryProvider} test
- *
- * @author Tom Oram <tom@scl.co.uk>
  */
 class ObjectRepositoryProviderTest extends TestCase
 {
-    /**
-     * @var \BjyAuthorize\Provider\Role\ObjectRepositoryProvider
-     */
+    /** @var ObjectRepositoryProvider */
     private $provider;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var MockObject */
     private $repository;
 
     /**
@@ -30,18 +29,17 @@ class ObjectRepositoryProviderTest extends TestCase
     protected function setUp(): void
     {
         $this->repository = $this->createMock(ObjectRepository::class);
-        $this->provider = new ObjectRepositoryProvider($this->repository);
+        $this->provider   = new ObjectRepositoryProvider($this->repository);
     }
 
     /**
      * @param string $name
      * @param string $parent
-     *
-     * @return \PHPUnit\Framework\MockObject\MockObject|\BjyAuthorize\Acl\HierarchicalRoleInterface
+     * @return MockObject|HierarchicalRoleInterface
      */
     private function createRoleMock($name, $parent)
     {
-        $role = $this->createMock('BjyAuthorize\Acl\HierarchicalRoleInterface');
+        $role = $this->createMock(HierarchicalRoleInterface::class);
         $role->expects($this->atLeastOnce())
             ->method('getRoleId')
             ->will($this->returnValue($name));
@@ -60,9 +58,9 @@ class ObjectRepositoryProviderTest extends TestCase
     {
         // Set up mocks
         $roles = [
-            new \stdClass(), // to be skipped
+            new stdClass(), // to be skipped
             $this->createRoleMock('role1', null),
-            $this->createRoleMock('role2', null)
+            $this->createRoleMock('role2', null),
         ];
 
         $this->repository->expects($this->once())
@@ -88,7 +86,7 @@ class ObjectRepositoryProviderTest extends TestCase
         $roles = [
             $role1,
             $this->createRoleMock('role2', null),
-            $this->createRoleMock('role3', $role1)
+            $this->createRoleMock('role3', $role1),
         ];
 
         $this->repository->expects($this->once())
@@ -97,7 +95,7 @@ class ObjectRepositoryProviderTest extends TestCase
 
         // Set up the expected outcome
         $expectedRole1 = new Role('role1', null);
-        $expects = [
+        $expects       = [
             $expectedRole1,
             new Role('role2', null),
             new Role('role3', $expectedRole1),

--- a/test/Service/AuthenticationIdentityProviderServiceFactoryTest.php
+++ b/test/Service/AuthenticationIdentityProviderServiceFactoryTest.php
@@ -1,16 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\AuthenticationIdentityProviderServiceFactory;
 use Interop\Container\ContainerInterface;
+use Laminas\Authentication\AuthenticationService;
 use LmcUser\Service\User;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Factory test for {@see \BjyAuthorize\Service\AuthenticationIdentityProviderServiceFactory}
- *
- * @author Ingo Walz <ingo.walz@googlemail.com>
  */
 class AuthenticationIdentityProviderServiceFactoryTest extends TestCase
 {
@@ -22,12 +23,12 @@ class AuthenticationIdentityProviderServiceFactoryTest extends TestCase
     public function testCreateService()
     {
         $config = [
-            'default_role' => 'test-guest',
+            'default_role'       => 'test-guest',
             'authenticated_role' => 'test-user',
         ];
 
-        $user = $this->getMockBuilder(User::class)->getMock();
-        $auth = $this->createMock('Laminas\\Authentication\\AuthenticationService');
+        $user      = $this->getMockBuilder(User::class)->getMock();
+        $auth      = $this->createMock(AuthenticationService::class);
         $container = $this->createMock(ContainerInterface::class);
 
         $user->expects($this->once())->method('getAuthService')->will($this->returnValue($auth));
@@ -48,7 +49,10 @@ class AuthenticationIdentityProviderServiceFactoryTest extends TestCase
             );
 
         $authenticationFactory = new AuthenticationIdentityProviderServiceFactory();
-        $authentication = $authenticationFactory($container, AuthenticationIdentityProviderServiceFactory::class);
+        $authentication        = $authenticationFactory(
+            $container,
+            AuthenticationIdentityProviderServiceFactory::class
+        );
 
         $this->assertEquals($authentication->getDefaultRole(), 'test-guest');
         $this->assertEquals($authentication->getAuthenticatedRole(), 'test-user');

--- a/test/Service/AuthorizeAwareServiceInitializerTest.php
+++ b/test/Service/AuthorizeAwareServiceInitializerTest.php
@@ -1,43 +1,39 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\Authorize;
 use BjyAuthorize\Service\AuthorizeAwareInterface;
 use BjyAuthorize\Service\AuthorizeAwareServiceInitializer;
 use Interop\Container\ContainerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\AuthorizeAwareServiceInitializer}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class AuthorizeAwareServiceInitializerTest extends TestCase
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var MockObject */
     protected $authorize;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject
-     */
+    /** @var MockObject */
     protected $container;
 
-    /**
-     * @var \BjyAuthorize\Service\AuthorizeAwareServiceInitializer
-     */
+    /** @var AuthorizeAwareServiceInitializer */
     protected $initializer;
 
     /**
      * {@inheritDoc}
+     *
      * @see \PHPUnit\Framework\TestCase::setUp()
      */
     protected function setUp(): void
     {
-        $this->authorize = $this->getMockBuilder(Authorize::class)->disableOriginalConstructor()->getMock();
-        $this->container = $this->createMock(ContainerInterface::class);
+        $this->authorize   = $this->getMockBuilder(Authorize::class)->disableOriginalConstructor()->getMock();
+        $this->container   = $this->createMock(ContainerInterface::class);
         $this->initializer = new AuthorizeAwareServiceInitializer();
 
         $this->container->expects($this->any())->method('get')->will($this->returnValue($this->authorize));
@@ -45,6 +41,7 @@ class AuthorizeAwareServiceInitializerTest extends TestCase
 
     /**
      * {@inheritDoc}
+     *
      * @see \PHPUnit\Framework\TestCase::tearDown()
      */
     protected function tearDown(): void

--- a/test/Service/AuthorizeFactoryTest.php
+++ b/test/Service/AuthorizeFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\Authorize;
@@ -9,8 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\AuthorizeFactory}
- *
- * @author Christian Bergau <cbergau86@gmail.com>
  */
 class AuthorizeFactoryTest extends TestCase
 {

--- a/test/Service/AuthorizeTest.php
+++ b/test/Service/AuthorizeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Acl\Role;
@@ -11,6 +13,7 @@ use BjyAuthorize\Service\GuardsServiceFactory;
 use BjyAuthorize\Service\ResourceProvidersServiceFactory;
 use BjyAuthorize\Service\RoleProvidersServiceFactory;
 use BjyAuthorize\Service\RuleProvidersServiceFactory;
+use InvalidArgumentException;
 use Laminas\Cache\Storage\Adapter\Filesystem;
 use Laminas\Permissions\Acl\Acl;
 use Laminas\Permissions\Acl\Resource\GenericResource;
@@ -20,8 +23,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\Authorize}
- *
- * @author Christian Bergau <cbergau86@gmail.com>
  */
 class AuthorizeTest extends TestCase
 {
@@ -30,6 +31,7 @@ class AuthorizeTest extends TestCase
 
     /**
      * {@inheritDoc}
+     *
      * @see \PHPUnit\Framework\TestCase::setUp()
      */
     protected function setUp(): void
@@ -68,6 +70,7 @@ class AuthorizeTest extends TestCase
 
     /**
      * {@inheritDoc}
+     *
      * @see \PHPUnit\Framework\TestCase::tearDown()
      */
     protected function tearDown(): void
@@ -120,7 +123,7 @@ class AuthorizeTest extends TestCase
      */
     public function testLoadWritesAclToCacheIfCacheIsEnabledButAclIsNotStoredInCache()
     {
-        $cache = $this->getMockBuilder('Laminas\Cache\Storage\Adapter\Filesystem')
+        $cache = $this->getMockBuilder(Filesystem::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -152,7 +155,6 @@ class AuthorizeTest extends TestCase
         $authorize = new Authorize(['cache_key' => 'acl'], $serviceManager);
         $authorize->load();
     }
-
 
     /**
      * @group bjyoungblood/BjyAuthorize#258
@@ -217,13 +219,12 @@ class AuthorizeTest extends TestCase
         $this->assertTrue($acl->hasResource('test'));
     }
 
-
     /**
      * @group bjyoungblood/BjyAuthorize#258
      */
     public function testCanAddNonTraversableResourceToLoadResourceThrowsInvalidArgumentException()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $serviceManager = $this->serviceManager;
         $serviceManager->setAllowOverride(true);

--- a/test/Service/BaseProvidersServiceFactoryTest.php
+++ b/test/Service/BaseProvidersServiceFactoryTest.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
-use \PHPUnit\Framework\TestCase;
-use Interop\Container\ContainerInterface;
-use BjyAuthorize\Service\BaseProvidersServiceFactory;
 use BjyAuthorize\Provider\Resource\ProviderInterface;
+use BjyAuthorize\Service\BaseProvidersServiceFactory;
+use BjyAuthorizeTest\Service\MockProvider;
+use Interop\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
+
+use function array_filter;
+use function array_shift;
+use function in_array;
 
 /**
  * Test for {@see \BjyAuthorize\Service\ResourceProvidersServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class BaseProvidersServiceFactoryTest extends TestCase
 {
@@ -19,14 +24,14 @@ class BaseProvidersServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = $this->getMockForAbstractClass(BaseProvidersServiceFactory::class);
+        $factory   = $this->getMockForAbstractClass(BaseProvidersServiceFactory::class);
         $container = $this->createMock(ContainerInterface::class);
-        $foo = $this->createMock(ProviderInterface::class);
-        $bar = $this->createMock(ProviderInterface::class);
-        $config = [
+        $foo       = $this->createMock(ProviderInterface::class);
+        $bar       = $this->createMock(ProviderInterface::class);
+        $config    = [
             'providers' => [
-                'foo' => [],
-                'bar' => [],
+                'foo'                            => [],
+                'bar'                            => [],
                 __NAMESPACE__ . '\\MockProvider' => ['option' => 'value'],
             ],
         ];
@@ -77,7 +82,7 @@ class BaseProvidersServiceFactoryTest extends TestCase
 
         $this->assertCount(1, $invokableProvider);
 
-        /* @var $invokableGuard \BjyAuthorizeTest\Service\MockProvider */
+        /** @var MockProvider $invokableProvider */
         $invokableProvider = array_shift($invokableProvider);
 
         $this->assertInstanceOf(__NAMESPACE__ . '\\MockProvider', $invokableProvider);

--- a/test/Service/CacheFactoryTest.php
+++ b/test/Service/CacheFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\CacheFactory;
@@ -9,8 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * PHPUnit tests for {@see \BjyAuthorize\Service\CacheFactory}
- *
- * @author Christian Bergau <cbergau86@gmail.com>
  */
 class CacheFactoryTest extends TestCase
 {
@@ -20,15 +20,15 @@ class CacheFactoryTest extends TestCase
     public function testInvoke()
     {
         $container = $this->createMock(ContainerInterface::class);
-        $config = [
+        $config    = [
             'cache_options' => [
                 'adapter' => [
                     'name' => 'memory',
                 ],
                 'plugins' => [
                     'serializer',
-                ]
-            ]
+                ],
+            ],
         ];
 
         $container

--- a/test/Service/CacheKeyGeneratorFactoryTest.php
+++ b/test/Service/CacheKeyGeneratorFactoryTest.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\CacheKeyGeneratorFactory;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 
+use function is_callable;
+
 /**
  * PHPUnit tests for {@see \BjyAuthorize\Service\CacheKeyGeneratorFactory}
- *
- * @author Steve Rhoades <sedonami@gmail.com>
  */
 class CacheKeyGeneratorFactoryTest extends TestCase
 {
@@ -19,7 +21,7 @@ class CacheKeyGeneratorFactoryTest extends TestCase
     public function testInvokeReturnsDefaultCallable()
     {
         $container = $this->createMock(ContainerInterface::class);
-        $config = [];
+        $config    = [];
 
         $container
             ->expects($this->any())
@@ -40,8 +42,8 @@ class CacheKeyGeneratorFactoryTest extends TestCase
     public function testInvokeReturnsCacheKeyGeneratorCallable()
     {
         $container = $this->createMock(ContainerInterface::class);
-        $config = [
-            'cache_key' => 'some_new_value'
+        $config    = [
+            'cache_key' => 'some_new_value',
         ];
 
         $container

--- a/test/Service/ConfigResourceProviderServiceFactoryTest.php
+++ b/test/Service/ConfigResourceProviderServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Provider\Resource\Config;
@@ -9,8 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\ConfigResourceProviderServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigResourceProviderServiceFactoryTest extends TestCase
 {
@@ -19,9 +19,9 @@ class ConfigResourceProviderServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new ConfigResourceProviderServiceFactory();
+        $factory   = new ConfigResourceProviderServiceFactory();
         $container = $this->createMock(ContainerInterface::class);
-        $config = [
+        $config    = [
             'resource_providers' => [
                 Config::class => [],
             ],

--- a/test/Service/ConfigRoleProviderServiceFactoryTest.php
+++ b/test/Service/ConfigRoleProviderServiceFactoryTest.php
@@ -1,16 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
-use \PHPUnit\Framework\TestCase;
-use BjyAuthorize\Service\ConfigRoleProviderServiceFactory;
 use BjyAuthorize\Provider\Role\Config;
+use BjyAuthorize\Service\ConfigRoleProviderServiceFactory;
 use Interop\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\ConfigRoleProviderServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigRoleProviderServiceFactoryTest extends TestCase
 {
@@ -19,9 +19,9 @@ class ConfigRoleProviderServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new ConfigRoleProviderServiceFactory();
+        $factory   = new ConfigRoleProviderServiceFactory();
         $container = $this->createMock(ContainerInterface::class);
-        $config = [
+        $config    = [
             'role_providers' => [
                 Config::class => [],
             ],
@@ -33,7 +33,7 @@ class ConfigRoleProviderServiceFactoryTest extends TestCase
             ->with('BjyAuthorize\Config')
             ->will($this->returnValue($config));
 
-        $guard = $factory($container,ConfigRoleProviderServiceFactory::class);
+        $guard = $factory($container, ConfigRoleProviderServiceFactory::class);
 
         $this->assertInstanceOf(Config::class, $guard);
     }

--- a/test/Service/ConfigRuleProviderServiceFactoryTest.php
+++ b/test/Service/ConfigRuleProviderServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Provider\Rule\Config;
@@ -9,8 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\ConfigRuleProviderServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigRuleProviderServiceFactoryTest extends TestCase
 {
@@ -19,9 +19,9 @@ class ConfigRuleProviderServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new ConfigRuleProviderServiceFactory();
+        $factory   = new ConfigRuleProviderServiceFactory();
         $container = $this->createMock(ContainerInterface::class);
-        $config = ['rule_providers' => [Config::class => []]];
+        $config    = ['rule_providers' => [Config::class => []]];
 
         $container
             ->expects($this->any())

--- a/test/Service/ConfigServiceFactoryTest.php
+++ b/test/Service/ConfigServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\ConfigServiceFactory;
@@ -8,8 +10,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\ConfigServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ConfigServiceFactoryTest extends TestCase
 {
@@ -18,7 +18,7 @@ class ConfigServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new ConfigServiceFactory();
+        $factory   = new ConfigServiceFactory();
         $container = $this->createMock(ContainerInterface::class);
 
         $container

--- a/test/Service/ControllerGuardServiceFactoryTest.php
+++ b/test/Service/ControllerGuardServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Guard\Controller;
@@ -9,8 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\ControllerGuardServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class ControllerGuardServiceFactoryTest extends TestCase
 {
@@ -19,9 +19,9 @@ class ControllerGuardServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new ControllerGuardServiceFactory();
+        $factory   = new ControllerGuardServiceFactory();
         $container = $this->createMock(ContainerInterface::class);
-        $config = [
+        $config    = [
             'guards' => [
                 Controller::class => [],
             ],

--- a/test/Service/IdentityProviderServiceFactoryTest.php
+++ b/test/Service/IdentityProviderServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Provider\Identity\ProviderInterface;
@@ -9,8 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\IdentityProviderServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class IdentityProviderServiceFactoryTest extends TestCase
 {
@@ -19,10 +19,10 @@ class IdentityProviderServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new IdentityProviderServiceFactory();
-        $container = $this->createMock(ContainerInterface::class);
+        $factory          = new IdentityProviderServiceFactory();
+        $container        = $this->createMock(ContainerInterface::class);
         $identityProvider = $this->createMock(ProviderInterface::class);
-        $config = ['identity_provider' => 'foo'];
+        $config           = ['identity_provider' => 'foo'];
 
         $container
             ->expects($this->any())

--- a/test/Service/LaminasDbRoleProviderServiceFactoryTest.php
+++ b/test/Service/LaminasDbRoleProviderServiceFactoryTest.php
@@ -1,16 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
-use \PHPUnit\Framework\TestCase;
-use BjyAuthorize\Service\LaminasDbRoleProviderServiceFactory;
 use BjyAuthorize\Provider\Role\LaminasDb;
+use BjyAuthorize\Service\LaminasDbRoleProviderServiceFactory;
 use Interop\Container\ContainerInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\LaminasDbRoleProviderServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class LaminasDbRoleProviderServiceFactoryTest extends TestCase
 {
@@ -19,9 +19,9 @@ class LaminasDbRoleProviderServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new LaminasDbRoleProviderServiceFactory();
+        $factory   = new LaminasDbRoleProviderServiceFactory();
         $container = $this->createMock(ContainerInterface::class);
-        $config = [
+        $config    = [
             'role_providers' => [
                 LaminasDb::class => [],
             ],

--- a/test/Service/MockProvider.php
+++ b/test/Service/MockProvider.php
@@ -1,33 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
-use Laminas\ServiceManager\ServiceLocatorInterface;
-use Interop\Container\Exception\ContainerException;
 use Interop\Container\ContainerInterface;
 
-/**
- * @author Marco Pivetta <ocramius@gmail.com>s
- */
 class MockProvider
 {
-    /**
-     * @var array
-     */
+    /** @var array */
     public $options;
 
-    /**
-     * @var \Interop\Container\ContainerInterface
-     */
+    /** @var ContainerInterface */
     public $container;
 
     /**
      * @param array $options
-     * @param \Interop\Container\ContainerInterface $container
      */
     public function __construct(array $options, ContainerInterface $container)
     {
-        $this->options = $options;
+        $this->options   = $options;
         $this->container = $container;
     }
 }

--- a/test/Service/ObjectRepositoryRoleProviderFactoryTest.php
+++ b/test/Service/ObjectRepositoryRoleProviderFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Provider\Role\ObjectRepositoryProvider;
@@ -11,8 +13,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * {@see \BjyAuthorize\Service\ObjectRepositoryRoleProviderFactory} test
- *
- * @author Tom Oram <tom@scl.co.uk>
  */
 class ObjectRepositoryRoleProviderFactoryTest extends TestCase
 {
@@ -21,10 +21,10 @@ class ObjectRepositoryRoleProviderFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $container = $this->createMock(ContainerInterface::class);
+        $container     = $this->createMock(ContainerInterface::class);
         $entityManager = $this->createMock(ObjectManager::class);
-        $repository = $this->createMock(ObjectRepository::class);
-        $factory = new ObjectRepositoryRoleProviderFactory();
+        $repository    = $this->createMock(ObjectRepository::class);
+        $factory       = new ObjectRepositoryRoleProviderFactory();
 
         $testClassName = 'TheTestClass';
 
@@ -32,7 +32,7 @@ class ObjectRepositoryRoleProviderFactoryTest extends TestCase
             'role_providers' => [
                 ObjectRepositoryProvider::class => [
                     'role_entity_class' => $testClassName,
-                    'object_manager' => 'doctrine.entitymanager.orm_default',
+                    'object_manager'    => 'doctrine.entitymanager.orm_default',
                 ],
             ],
         ];

--- a/test/Service/RoleCollectorServiceFactoryTest.php
+++ b/test/Service/RoleCollectorServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Collector\RoleCollector;
@@ -10,8 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\RoleCollectorServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RoleCollectorServiceFactoryTest extends TestCase
 {
@@ -20,8 +20,8 @@ class RoleCollectorServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new RoleCollectorServiceFactory();
-        $container = $this->createMock(ContainerInterface::class);
+        $factory          = new RoleCollectorServiceFactory();
+        $container        = $this->createMock(ContainerInterface::class);
         $identityProvider = $this->createMock(ProviderInterface::class);
 
         $container

--- a/test/Service/RouteGuardServiceFactoryTest.php
+++ b/test/Service/RouteGuardServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Guard\Route;
@@ -10,8 +12,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\RouteGuardServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RouteGuardServiceFactoryTest extends TestCase
 {
@@ -20,9 +20,9 @@ class RouteGuardServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new RouteGuardServiceFactory();
+        $factory   = new RouteGuardServiceFactory();
         $container = $this->createMock(ContainerInterface::class);
-        $config = [
+        $config    = [
             'guards' => [
                 Route::class => [],
             ],

--- a/test/Service/UnauthorizedStrategyServiceFactoryTest.php
+++ b/test/Service/UnauthorizedStrategyServiceFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\Service;
 
 use BjyAuthorize\Service\UnauthorizedStrategyServiceFactory;
@@ -9,8 +11,6 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * Test for {@see \BjyAuthorize\Service\UnauthorizedStrategyServiceFactory}
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class UnauthorizedStrategyServiceFactoryTest extends TestCase
 {
@@ -19,9 +19,9 @@ class UnauthorizedStrategyServiceFactoryTest extends TestCase
      */
     public function testInvoke()
     {
-        $factory = new UnauthorizedStrategyServiceFactory();
+        $factory            = new UnauthorizedStrategyServiceFactory();
         $containerInterface = $this->createMock(ContainerInterface::class);
-        $config = [
+        $config             = [
             'template' => 'foo/bar',
         ];
 

--- a/test/View/Helper/IsAllowedTest.php
+++ b/test/View/Helper/IsAllowedTest.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\View\Helper;
 
-use \PHPUnit\Framework\TestCase;
+use BjyAuthorize\Service\Authorize;
 use BjyAuthorize\View\Helper\IsAllowed;
+use PHPUnit\Framework\TestCase;
 
 /**
  * IsAllowed view helper test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class IsAllowedTest extends TestCase
 {
@@ -17,7 +18,7 @@ class IsAllowedTest extends TestCase
      */
     public function testIsAllowed()
     {
-        $authorize = $this->getMockBuilder('BjyAuthorize\\Service\\Authorize')->disableOriginalConstructor()->getMock();
+        $authorize = $this->getMockBuilder(Authorize::class)->disableOriginalConstructor()->getMock();
         $authorize
             ->expects($this->once())
             ->method('isAllowed')
@@ -27,7 +28,7 @@ class IsAllowedTest extends TestCase
         $plugin = new IsAllowed($authorize);
         $this->assertTrue($plugin->__invoke('test', 'privilege'));
 
-        $authorize2 = $this->getMockBuilder('BjyAuthorize\\Service\\Authorize')->disableOriginalConstructor()->getMock();
+        $authorize2 = $this->getMockBuilder(Authorize::class)->disableOriginalConstructor()->getMock();
         $authorize2
             ->expects($this->once())
             ->method('isAllowed')

--- a/test/View/RedirectionStrategyTest.php
+++ b/test/View/RedirectionStrategyTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\View;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
@@ -12,19 +14,15 @@ use Laminas\Mvc\Application;
 use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteInterface;
 use Laminas\Router\RouteMatch;
-use PHPUnit\Framework\TestCase;
 use Laminas\Stdlib\ResponseInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * UnauthorizedStrategyTest view strategy test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class RedirectionStrategyTest extends TestCase
 {
-    /**
-     * @var \BjyAuthorize\View\RedirectionStrategy
-     */
+    /** @var RedirectionStrategy */
     protected $strategy;
 
     /**
@@ -71,8 +69,8 @@ class RedirectionStrategyTest extends TestCase
      */
     public function testWillIgnoreUnrecognizedResponse()
     {
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $response = $this->createMock(ResponseInterface::class);
+        $mvcEvent   = $this->createMock(MvcEvent::class);
+        $response   = $this->createMock(ResponseInterface::class);
         $routeMatch = $this->getMockBuilder(RouteMatch::class)->disableOriginalConstructor()->getMock();
 
         $mvcEvent->expects($this->any())->method('getResponse')->will($this->returnValue($response));
@@ -88,10 +86,10 @@ class RedirectionStrategyTest extends TestCase
      */
     public function testWillIgnoreUnrecognizedErrorType()
     {
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $response = $this->createMock(Response::class);
+        $mvcEvent   = $this->createMock(MvcEvent::class);
+        $response   = $this->createMock(Response::class);
         $routeMatch = $this->getMockBuilder(RouteMatch::class)->disableOriginalConstructor()->getMock();
-        $route = $this->createMock(RouteInterface::class);
+        $route      = $this->createMock(RouteInterface::class);
 
         $mvcEvent->expects($this->any())->method('getResponse')->will($this->returnValue($response));
         $mvcEvent->expects($this->any())->method('getRouteMatch')->will($this->returnValue($routeMatch));
@@ -107,8 +105,8 @@ class RedirectionStrategyTest extends TestCase
      */
     public function testWillIgnoreOnExistingResult()
     {
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $response = $this->createMock(Response::class);
+        $mvcEvent   = $this->createMock(MvcEvent::class);
+        $response   = $this->createMock(Response::class);
         $routeMatch = $this->getMockBuilder(RouteMatch::class)->disableOriginalConstructor()->getMock();
 
         $mvcEvent->expects($this->any())->method('getResult')->will($this->returnValue($response));
@@ -145,11 +143,11 @@ class RedirectionStrategyTest extends TestCase
         $this->strategy->setRedirectRoute('redirect/route');
         $this->strategy->setRedirectUri(null);
 
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $response = $this->createMock(Response::class);
+        $mvcEvent   = $this->createMock(MvcEvent::class);
+        $response   = $this->createMock(Response::class);
         $routeMatch = $this->getMockBuilder(RouteMatch::class)->disableOriginalConstructor()->getMock();
-        $route = $this->getMockForAbstractClass(RouteInterface::class, [], '', true, true, true, ['assemble']);
-        $headers = $this->createMock(Headers::class);
+        $route      = $this->getMockForAbstractClass(RouteInterface::class, [], '', true, true, true, ['assemble']);
+        $headers    = $this->createMock(Headers::class);
 
         $mvcEvent->expects($this->any())->method('getResponse')->will($this->returnValue($response));
         $mvcEvent->expects($this->any())->method('getRouteMatch')->will($this->returnValue($routeMatch));
@@ -180,11 +178,11 @@ class RedirectionStrategyTest extends TestCase
     {
         $this->strategy->setRedirectUri('http://www.example.org/');
 
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $response = $this->createMock(Response::class);
+        $mvcEvent   = $this->createMock(MvcEvent::class);
+        $response   = $this->createMock(Response::class);
         $routeMatch = $this->getMockBuilder(RouteMatch::class)->disableOriginalConstructor()->getMock();
-        $route = $this->createMock(RouteInterface::class);
-        $headers = $this->createMock(Headers::class);
+        $route      = $this->createMock(RouteInterface::class);
+        $headers    = $this->createMock(Headers::class);
 
         $mvcEvent->expects($this->any())->method('getResponse')->will($this->returnValue($response));
         $mvcEvent->expects($this->any())->method('getRouteMatch')->will($this->returnValue($routeMatch));
@@ -209,12 +207,12 @@ class RedirectionStrategyTest extends TestCase
     {
         $this->strategy->setRedirectUri('http://www.example.org/');
 
-        $mvcEvent = $this->createMock(MvcEvent::class);
-        $response = $this->createMock(Response::class);
+        $mvcEvent   = $this->createMock(MvcEvent::class);
+        $response   = $this->createMock(Response::class);
         $routeMatch = $this->getMockBuilder(RouteMatch::class)->disableOriginalConstructor()->getMock();
-        $route = $this->createMock(RouteInterface::class);
-        $headers = $this->createMock(Headers::class);
-        $exception = $this->createMock(UnAuthorizedException::class);
+        $route      = $this->createMock(RouteInterface::class);
+        $headers    = $this->createMock(Headers::class);
+        $exception  = $this->createMock(UnAuthorizedException::class);
 
         $mvcEvent->expects($this->any())->method('getResponse')->will($this->returnValue($response));
         $mvcEvent->expects($this->any())->method('getRouteMatch')->will($this->returnValue($routeMatch));

--- a/test/View/UnauthorizedStrategyTest.php
+++ b/test/View/UnauthorizedStrategyTest.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace BjyAuthorizeTest\View;
 
 use BjyAuthorize\Exception\UnAuthorizedException;
 use BjyAuthorize\View\UnauthorizedStrategy;
+use Exception;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Http\Response;
 use Laminas\Mvc\Application;
@@ -11,17 +14,14 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Stdlib\ResponseInterface;
 use Laminas\View\Model\ModelInterface;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 /**
  * UnauthorizedStrategyTest view strategy test
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class UnauthorizedStrategyTest extends TestCase
 {
-    /**
-     * @var UnauthorizedStrategy
-     */
+    /** @var UnauthorizedStrategy */
     protected $strategy;
 
     /**
@@ -105,10 +105,10 @@ class UnauthorizedStrategyTest extends TestCase
             ->method('addChild')
             ->will(
                 $this->returnCallback(
-                    function (ModelInterface $model) use ($test) {
+                    function (ModelInterface $model) {
                         // using a return callback because of a bug in HHVM
                         if ('template/name' !== $model->getTemplate()) {
-                            throw new \UnexpectedValueException('Template name does not match expectations!');
+                            throw new UnexpectedValueException('Template name does not match expectations!');
                         }
                     }
                 )
@@ -118,10 +118,10 @@ class UnauthorizedStrategyTest extends TestCase
             ->method('setResponse')
             ->will(
                 $this->returnCallback(
-                    function (Response $response) use ($test) {
+                    function (Response $response) {
                         // using a return callback because of a bug in HHVM
                         if (403 !== $response->getStatusCode()) {
-                            throw new \UnexpectedValueException('Response code not match expectations!');
+                            throw new UnexpectedValueException('Response code not match expectations!');
                         }
                     }
                 )
@@ -135,7 +135,7 @@ class UnauthorizedStrategyTest extends TestCase
      */
     public function testIgnoresUnknownExceptions()
     {
-        $exception = $this->createMock(\Exception::class);
+        $exception = $this->createMock(Exception::class);
         $viewModel = $this->createMock(ModelInterface::class);
         $mvcEvent  = $this->createMock(MvcEvent::class);
 
@@ -180,7 +180,7 @@ class UnauthorizedStrategyTest extends TestCase
      */
     public function testIgnoresOnExistingResponse()
     {
-        $response = $this->createMock(ResponseInterface::class);
+        $response  = $this->createMock(ResponseInterface::class);
         $viewModel = $this->createMock(ModelInterface::class);
         $mvcEvent  = $this->createMock(MvcEvent::class);
 


### PR DESCRIPTION
Currently, this project does not follow any coding standards. I have added the [laminas-coding-standard](https://github.com/laminas/laminas-coding-standard) v2.3. Coding standards will automatically be checked in the CI pipeline set up in #31.

Additionally, I have applied the coding standards using `composer cs-fix`. This introduced quite a lot of changes, of which most are of rather cosmetic nature. This includes:
 - class constants which did not have a visibility before are now marked as `public`
 - PHP functions from the global namespace are now explicitly imported
 - `declare(strict_types=1);` was added to all files

Especially the last point, strict types, could theoretically cause some issues. There was one issue with the test cases, which I fixed in 812764b. I didn't find any further issues, but it might be good if someone could test it with their applications as well. This can be done by installing the version from this PR using composer:

```
{
    "require": {
        "kokspflanze/bjy-authorize": "dev-feature/coding-standard"
    }
    "repositories":[
        {
            "type": "vcs",
            "url": "git@github.com:driehle/BjyAuthorize.git"
        }
    ]
}
```