### PR TITLE
add support to php 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "^7.3 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "laminas/laminas-permissions-acl": "^2.8.0",
         "laminas/laminas-mvc":             "^3.2.0",
         "laminas/laminas-eventmanager":    "^3.4.0",
@@ -38,7 +38,7 @@
     "require-dev": {
         "phpunit/phpunit":                 "^9.5.9",
         "laminas/laminas-coding-standard": "^2.3.0",
-        "laminas/laminas-db":              "^2.13.4",
+        "laminas/laminas-db":              "^2.20.0",
         "doctrine/persistence":            "^1.3.8 || ^2.2.2",
         "laminas/laminas-developer-tools": "^2.1.1",
         "lm-commons/lmc-user":             "^3.5.0",
@@ -61,6 +61,9 @@
     },
     "config": {
         "sort-packages": true,
+        "platform": {
+            "php": "8.3.14"
+        },
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
Hello, we will need support for php 8.4 for this library before going on laminas authorization.
We would like to upgrade to php 8.4 first, so this PR will make this fork compatible with the latest version.

What do you think of it ?

Thanks in advance, 

Pierre